### PR TITLE
feat(backend): refine, script generation, and approve API routes (#14)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,14 @@
 {
   "permissions": {
     "allow": [
-      "mcp__playwright__browser_snapshot"
+      "mcp__playwright__browser_snapshot",
+      "mcp__github__get_me",
+      "Bash(git remote *)",
+      "mcp__github__issue_write",
+      "Bash(git checkout *)",
+      "Bash(npm run *)",
+      "Bash(npx eslint *)",
+      "Bash(git add *)"
     ]
   }
 }

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,12 @@
+# Google AI Studio — server-side only, never expose to client
+GEMINI_API_KEY=
+
+# Supabase — project URL and anon key are safe for client use
+NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_ANON_KEY=
+
+# Supabase — service role key is server-side only, never prefix with NEXT_PUBLIC_
+SUPABASE_SERVICE_ROLE_KEY=
+
+# Base URL for share links (e.g. https://comicly.vercel.app or http://localhost:3000)
+NEXT_PUBLIC_BASE_URL=http://localhost:3000

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.local.example
 
 # vercel
 .vercel
@@ -40,3 +41,5 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 .playwright-mcp
+
+/references

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "github": {
+      "command": "cmd",
+      "args": ["/c", "npx", "-y", "@modelcontextprotocol/server-github"]
+    }
+  }
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,12 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  serverExternalPackages: ["@google/genai"],
+  experimental: {
+    serverActions: {
+      bodySizeLimit: "10mb",
+    },
+  },
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "@supabase/supabase-js": "^2.103.3",
         "next": "16.2.2",
         "react": "19.2.4",
-        "react-dom": "19.2.4"
+        "react-dom": "19.2.4",
+        "swagger-ui-react": "^5.32.4"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -23,6 +24,7 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@types/swagger-ui-react": "^5.18.0",
         "@vitejs/plugin-react": "^6.0.1",
         "@vitest/coverage-v8": "^4.1.4",
         "eslint": "^9",
@@ -289,8 +291,19 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-      "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime-corejs3": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.2.tgz",
+      "integrity": "sha512-Lc94FOD5+0aXhdb0Tdg3RUtqT6yWbI/BbFWvlaSJ3gAb9Ks+99nHRDKADVqC37er4eCB0fHyWT+y+K3QOvJKbw==",
+      "license": "MIT",
+      "dependencies": {
+        "core-js-pure": "^3.48.0"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1992,6 +2005,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -2095,6 +2115,701 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@swagger-api/apidom-ast": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ast/-/apidom-ast-1.10.2.tgz",
+      "integrity": "sha512-vTl8gWyeZaj887/NSWYs3as4K8wXHar5wY/606XRBjR2UgmJBokBgKjq7S23LW9tsYjsT4MjQKC8idjgw17xvg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-error": "^1.10.2",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0",
+        "unraw": "^3.0.0"
+      }
+    },
+    "node_modules/@swagger-api/apidom-core": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-core/-/apidom-core-1.10.2.tgz",
+      "integrity": "sha512-qryNBGHNWDvSRyK1w5rox0UOrHrVBjZOHgeXFpGHF+oBO7ntSc/H7BSiYMDR+KQESkzMcAxn4tZMLYItaBt06w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-ast": "^1.10.2",
+        "@swagger-api/apidom-error": "^1.10.2",
+        "@types/ramda": "~0.30.0",
+        "minim": "~0.23.8",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0",
+        "short-unique-id": "^5.3.2",
+        "ts-mixer": "^6.0.3"
+      }
+    },
+    "node_modules/@swagger-api/apidom-error": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-error/-/apidom-error-1.10.2.tgz",
+      "integrity": "sha512-SWyPyL5xwTUsDzPi0A5zwTFwqPezvlwj4opEqruqjESNTYupUA7+vt4Mdj7IlDaRYRG1qyCWQgKhIBXznVUD4w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.20.7"
+      }
+    },
+    "node_modules/@swagger-api/apidom-json-pointer": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-json-pointer/-/apidom-json-pointer-1.10.2.tgz",
+      "integrity": "sha512-zySHPqIXF4HZ3VWbHwTxO+H1e9dJw7mGHzoX+tZjx5wVyLQO3kZDCAAXzz3c3/TIY21Y2Zkpkez3q9hjFyuLvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-error": "^1.10.2",
+        "@swaggerexpert/json-pointer": "^2.10.1"
+      }
+    },
+    "node_modules/@swagger-api/apidom-ns-api-design-systems": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-api-design-systems/-/apidom-ns-api-design-systems-1.10.2.tgz",
+      "integrity": "sha512-MsZ4GWmWN7wkWv7G9Pwk8sHU1j0bwk7xoGeaZmNCylbTfYvGkg6jJGMHdAdQNCQXbbpfLeKt1O+3YCN//JUQ7w==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-error": "^1.10.2",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.10.2",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0",
+        "ts-mixer": "^6.0.3"
+      }
+    },
+    "node_modules/@swagger-api/apidom-ns-arazzo-1": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-arazzo-1/-/apidom-ns-arazzo-1-1.10.2.tgz",
+      "integrity": "sha512-fQSwDlIR85tbnLXAjtV/ypSGUBfrzFcZ4NbH6BL1DSTR4uEunVxAULdD4wlhCt9gGNDl/zxZD3vQtlYDkXDFmw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-ns-json-schema-2020-12": "^1.10.2",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0",
+        "ts-mixer": "^6.0.3"
+      }
+    },
+    "node_modules/@swagger-api/apidom-ns-asyncapi-2": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-1.10.2.tgz",
+      "integrity": "sha512-obWHe3pyAj65Nf9ISwnbtJ4C5mZ15C6mtQXxzHVW5maVZqlqt3s/YbPY87EqK9ArdNOwOZHkQt2Uth02GMmjxA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-ns-json-schema-draft-7": "^1.10.2",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0",
+        "ts-mixer": "^6.0.3"
+      }
+    },
+    "node_modules/@swagger-api/apidom-ns-asyncapi-3": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-3/-/apidom-ns-asyncapi-3-1.10.2.tgz",
+      "integrity": "sha512-yqNmXeObF2OLAusgGEapXz2CrGjXwkcfG3DYcQDtOvgRytvGZxC2EkCUR+wEXCVNYhoJ7QpVzzTJOHs3jOvptg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-ns-asyncapi-2": "^1.10.2",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0",
+        "ts-mixer": "^6.0.3"
+      }
+    },
+    "node_modules/@swagger-api/apidom-ns-json-schema-2019-09": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-2019-09/-/apidom-ns-json-schema-2019-09-1.10.2.tgz",
+      "integrity": "sha512-I1FaBoDFMjybF4QVsesIYl8OilkwycZ0mQ0jf1P++zfTRG27uIePB8M+Iuj6iqMsE3qpkjjJJ6ZLnrLPdKvmRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-error": "^1.10.2",
+        "@swagger-api/apidom-ns-json-schema-draft-7": "^1.10.2",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0",
+        "ts-mixer": "^6.0.4"
+      }
+    },
+    "node_modules/@swagger-api/apidom-ns-json-schema-2020-12": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-2020-12/-/apidom-ns-json-schema-2020-12-1.10.2.tgz",
+      "integrity": "sha512-lg9XfRlJRNoBa2EDGpEFc7HvFV39G6RG0/SbjQY0BE/WZer10wmfTCU7l3RUNJXRFGKH6/O/nsYgP7AFjTanXQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-error": "^1.10.2",
+        "@swagger-api/apidom-ns-json-schema-2019-09": "^1.10.2",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0",
+        "ts-mixer": "^6.0.4"
+      }
+    },
+    "node_modules/@swagger-api/apidom-ns-json-schema-draft-4": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-1.10.2.tgz",
+      "integrity": "sha512-C50KnSKynrmHky/oOB6+hHyZVpwng78Fz5aZjay3h8X5C/PJHmm3sDJFvF3/9wkYHO3N9sPp7cpu4Xm9VJ4/wQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-ast": "^1.10.2",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0",
+        "ts-mixer": "^6.0.4"
+      }
+    },
+    "node_modules/@swagger-api/apidom-ns-json-schema-draft-6": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-1.10.2.tgz",
+      "integrity": "sha512-/wiP8+2lF8UJRrkoQ9HvKnMbnqijk2uY/hAg+/Bo73T9NGKkEa29jYVUKYNYj7gJBw4hhkUHfHFWuZUpxPC4ZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-error": "^1.10.2",
+        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.10.2",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0",
+        "ts-mixer": "^6.0.4"
+      }
+    },
+    "node_modules/@swagger-api/apidom-ns-json-schema-draft-7": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-1.10.2.tgz",
+      "integrity": "sha512-firN/uvnVxQgACqcyzV3NU9qjbMvNMJkpmm3wOat3URmaFMaFBT3qjbU1pFHBGbnXI3+I9pQJZHmJSwqNzfUbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-error": "^1.10.2",
+        "@swagger-api/apidom-ns-json-schema-draft-6": "^1.10.2",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0",
+        "ts-mixer": "^6.0.4"
+      }
+    },
+    "node_modules/@swagger-api/apidom-ns-openapi-2": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-2/-/apidom-ns-openapi-2-1.10.2.tgz",
+      "integrity": "sha512-FK5kYvo/1uwAByumRVRsynBlnKxUUImfsjPEFgRCW6yhbCGRqN47NaZ7GYFHpbhjC3OmMN5/etYj6B0jnZx7Gg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-error": "^1.10.2",
+        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.10.2",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0",
+        "ts-mixer": "^6.0.3"
+      }
+    },
+    "node_modules/@swagger-api/apidom-ns-openapi-3-0": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-1.10.2.tgz",
+      "integrity": "sha512-ziyv85QbJYHRdc9oTEFBy3pxwxg7BW/a9GrwH01/SmuXVQPjLjwzRb+SjCxLogJppm0yjxOkDFI2VWPp2RADFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-error": "^1.10.2",
+        "@swagger-api/apidom-ns-json-schema-draft-4": "^1.10.2",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0",
+        "ts-mixer": "^6.0.3"
+      }
+    },
+    "node_modules/@swagger-api/apidom-ns-openapi-3-1": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-1.10.2.tgz",
+      "integrity": "sha512-ngcmO4dH77JT5hZB04OJdyTzgKnt2lNhAZQ+4wXjum/xhszjUmDhOeYfXdHw3Lm7MxsEsTesWzLYQ5LKADc41A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-ast": "^1.10.2",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-json-pointer": "^1.10.2",
+        "@swagger-api/apidom-ns-json-schema-2020-12": "^1.10.2",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.10.2",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0",
+        "ts-mixer": "^6.0.3"
+      }
+    },
+    "node_modules/@swagger-api/apidom-ns-openapi-3-2": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-2/-/apidom-ns-openapi-3-2-1.10.2.tgz",
+      "integrity": "sha512-3SWJ5ipWwn+w11HTUESWex/522jy2aGLzBqqMgH36sy+Wdwx+9Mw2bgSDqkxmNC5+jpzOGUOIWoQAMuCpS/Gzg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-ast": "^1.10.2",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-json-pointer": "^1.10.2",
+        "@swagger-api/apidom-ns-json-schema-2020-12": "^1.10.2",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.10.2",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.10.2",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0",
+        "ts-mixer": "^6.0.3"
+      }
+    },
+    "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-json": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-json/-/apidom-parser-adapter-api-design-systems-json-1.10.2.tgz",
+      "integrity": "sha512-kzhJUGzsJ38Uohj5xRQDkQC08rqNhatbqgD30LZ0/UWryJ9nAsjqK2ovuP9t+5WKcDE4iwcYeGSt1NA2XgEZwg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-ns-api-design-systems": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-json": "^1.10.2",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0"
+      }
+    },
+    "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/-/apidom-parser-adapter-api-design-systems-yaml-1.10.2.tgz",
+      "integrity": "sha512-i3CmSxJ/iG67ybRDAJ9xpuMrOMFvC/obX2lI36E0VZzBTb+llw4Zd5qFmBqNnImLpwdmk11Z1V7i+5HM+J7ijQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-ns-api-design-systems": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.2",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0"
+      }
+    },
+    "node_modules/@swagger-api/apidom-parser-adapter-arazzo-json-1": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-arazzo-json-1/-/apidom-parser-adapter-arazzo-json-1-1.10.2.tgz",
+      "integrity": "sha512-HwiUkwvo5i2hV2SS6KWrdj62BdceZGfhuXhr1il8akWekpU4jXPtr5pv4gOnKKJN7VgjAmwt/DlcCSRo1+9jVA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-ns-arazzo-1": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-json": "^1.10.2",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0"
+      }
+    },
+    "node_modules/@swagger-api/apidom-parser-adapter-arazzo-yaml-1": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-arazzo-yaml-1/-/apidom-parser-adapter-arazzo-yaml-1-1.10.2.tgz",
+      "integrity": "sha512-w8VTVuE7GPbRqWxvMgRoTb726JRsMhFPMfTBf8+MJ4pQThjk78dSXPV2Zlse71b2DWBuQy2sr6zGyLUNs/3ePQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-ns-arazzo-1": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.2",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0"
+      }
+    },
+    "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-json-2": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-1.10.2.tgz",
+      "integrity": "sha512-FDNjqmn2vV1jFoVVwQDO0XPPm8R5xzmcyY/6yBLFmKZADin3smSKVZ+njYHmfRjpspXwN0AwI0drdvuH0FZLJg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-ns-asyncapi-2": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-json": "^1.10.2",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0"
+      }
+    },
+    "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-json-3": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-3/-/apidom-parser-adapter-asyncapi-json-3-1.10.2.tgz",
+      "integrity": "sha512-x/0vM2nDDzYzFnXr69+so/KSH+2py2TiZd1K49pWcX8cHsPV1Y4Ppih7GVOMymd8m/IOCjLYlV7qt4eWDwdldg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-ns-asyncapi-3": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-json": "^1.10.2",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0"
+      }
+    },
+    "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-1.10.2.tgz",
+      "integrity": "sha512-2bVACmU9ZmAVVnqQWSc3Bs+xG0HHLU1tfZbYL8xNgSi8kw4HcnejF5mWtN+MLFzTaBmWCi2In7P7BYNR8+2Dyg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-ns-asyncapi-2": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.2",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0"
+      }
+    },
+    "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-3/-/apidom-parser-adapter-asyncapi-yaml-3-1.10.2.tgz",
+      "integrity": "sha512-oHpbf+iqBcDS3qtsipMpgCwAeckKMxg0qFKYTCRZyJdctRgupJTxVeir6t/SGo0Ny0a1iknt2LN0u5frEen0kg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-ns-asyncapi-3": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.2",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0"
+      }
+    },
+    "node_modules/@swagger-api/apidom-parser-adapter-json": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-json/-/apidom-parser-adapter-json-1.10.2.tgz",
+      "integrity": "sha512-VnwEkarKfsJYRF0zCI9AGiSIyBUXqS2d32KQuhVCt/HeuF1XO9sjeLjGiosA/24YVOnO0ul5TpiNFQn0pw89mA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-ast": "^1.10.2",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-error": "^1.10.2",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0",
+        "tree-sitter": "=0.21.1",
+        "tree-sitter-json": "=0.24.8",
+        "web-tree-sitter": "=0.24.5"
+      }
+    },
+    "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-2": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-2/-/apidom-parser-adapter-openapi-json-2-1.10.2.tgz",
+      "integrity": "sha512-+d/o/8TrNBjvFzgPb0RQhrCc8gOWnrHZF+xvCO5gwp+4MUr1XP1AJIox1e6t1SO+j7IQjiF2ocx2r7eFE5QC7w==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-ns-openapi-2": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-json": "^1.10.2",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0"
+      }
+    },
+    "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-0": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-1.10.2.tgz",
+      "integrity": "sha512-3ieUeX8/WywkUzdOO1U1QKQDNmpZFfOeTAeb4ISDd/PKOVwuEx/b0w5I8EuOu97tKAe3UUesEdii+pJlkcFlFw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-json": "^1.10.2",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0"
+      }
+    },
+    "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-1": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-1.10.2.tgz",
+      "integrity": "sha512-z0c7IgMPLSDhE+ldTb54Xlhq+yPF0w/8LHXyeHX4V6BS1VG3Utb+mM/qTVfy1Eo+p1KGNlwNDEPsBp6jIaVb5Q==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-json": "^1.10.2",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0"
+      }
+    },
+    "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-2": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-2/-/apidom-parser-adapter-openapi-json-3-2-1.10.2.tgz",
+      "integrity": "sha512-bx/kEIXWtpHu+4LEiyNdt0v8ER5EVwPjhQdlpOaC5qghnRH9aUYOTawZtVHsNHAQWTIMNn9DdPKYQgttQKD0Pw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-ns-openapi-3-2": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-json": "^1.10.2",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0"
+      }
+    },
+    "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-2": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-2/-/apidom-parser-adapter-openapi-yaml-2-1.10.2.tgz",
+      "integrity": "sha512-e86JUXHGGEVsO4/xpy/GRSvYXGN30hLt1lMUhjzCFuE95N6/K3hmQHE3rA/H7ot1ajCWUhzukW5rGQac79NIjA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-ns-openapi-2": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.2",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0"
+      }
+    },
+    "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-1.10.2.tgz",
+      "integrity": "sha512-ucfc13Ai31tJ0ruAm1YiHhqENgcBuiOXL00OhoICWA56ggAcnA5WfWmvtsXVMlZsTHVbhZP3XpsH5rui2N8u5w==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.2",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0"
+      }
+    },
+    "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-1.10.2.tgz",
+      "integrity": "sha512-7o8j93qgf9yYAaaJ/GpH+5sB3fC9EmvmjTCqlw5YWXp+cRgCn9q7f80Sv4+NjbracUafB6qL4i9F/m+Xs0XZaQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.2",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0"
+      }
+    },
+    "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-2/-/apidom-parser-adapter-openapi-yaml-3-2-1.10.2.tgz",
+      "integrity": "sha512-blDIeVmo8bpXYV/C+b6PYi54yS+5jPEZTFsK5jQ2NzpCPrkBPacp/KTuHBUBzJsYj4bj/ivRL3+JXGw4YovUHw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-ns-openapi-3-2": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.2",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0"
+      }
+    },
+    "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-1.10.2.tgz",
+      "integrity": "sha512-I5eCls8XS3SVEwH/cuL6T3iar1TPaFYh3gXwS/2rzP1aZQNKSHDP3y3ney7nAomKG4dFvE8Q248FL36arG7T/w==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-ast": "^1.10.2",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-error": "^1.10.2",
+        "@tree-sitter-grammars/tree-sitter-yaml": "=0.7.1",
+        "@types/ramda": "~0.30.0",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0",
+        "tree-sitter": "=0.22.4",
+        "web-tree-sitter": "=0.24.5"
+      }
+    },
+    "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2/node_modules/@tree-sitter-grammars/tree-sitter-yaml": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@tree-sitter-grammars/tree-sitter-yaml/-/tree-sitter-yaml-0.7.1.tgz",
+      "integrity": "sha512-AynBwkIoQCTgjDR33bDUp9Mqq+YTco0is3n5hRApMqG9of/6A4eQsfC1/uSEeHSUyMQSYawcAWamsexnVpIP4Q==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^8.3.1",
+        "node-gyp-build": "^4.8.4"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.22.4"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2/node_modules/tree-sitter": {
+      "version": "0.22.4",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.22.4.tgz",
+      "integrity": "sha512-usbHZP9/oxNsUY65MQUsduGRqDHQOou1cagUSwjhoSYAmSahjQDAVsh9s+SlZkn8X8+O1FULRGwHu7AFP3kjzg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      }
+    },
+    "node_modules/@swagger-api/apidom-reference": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@swagger-api/apidom-reference/-/apidom-reference-1.10.2.tgz",
+      "integrity": "sha512-H5UqOmae9CXdiLJbbh1j+/hwvcECmr6ci2XtUKTQpFviemvsIDZmPV1DKUAxCfzGr2iOkDO6SZc+/OEWlETqiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.26.10",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-error": "^1.10.2",
+        "@types/ramda": "~0.30.0",
+        "axios": "^1.15.0",
+        "minimatch": "^10.2.1",
+        "ramda": "~0.30.0",
+        "ramda-adjunct": "^5.0.0"
+      },
+      "optionalDependencies": {
+        "@swagger-api/apidom-json-pointer": "^1.10.2",
+        "@swagger-api/apidom-ns-arazzo-1": "^1.10.2",
+        "@swagger-api/apidom-ns-asyncapi-2": "^1.10.2",
+        "@swagger-api/apidom-ns-openapi-2": "^1.10.2",
+        "@swagger-api/apidom-ns-openapi-3-0": "^1.10.2",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.10.2",
+        "@swagger-api/apidom-ns-openapi-3-2": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-arazzo-json-1": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-arazzo-yaml-1": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-asyncapi-json-3": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-json": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-openapi-json-2": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-2": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": "^1.10.2",
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.10.2"
+      }
+    },
+    "node_modules/@swagger-api/apidom-reference/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@swagger-api/apidom-reference/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@swagger-api/apidom-reference/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@swaggerexpert/cookie": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@swaggerexpert/cookie/-/cookie-2.0.2.tgz",
+      "integrity": "sha512-DPI8YJ0Vznk4CT+ekn3rcFNq1uQwvUHZhH6WvTSPD0YKBIlMS9ur2RYKghXuxxOiqOam/i4lHJH4xTIiTgs3Mg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "apg-lite": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/@swaggerexpert/json-pointer": {
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@swaggerexpert/json-pointer/-/json-pointer-2.10.2.tgz",
+      "integrity": "sha512-qMx1nOrzoB+PF+pzb26Q4Tc2sOlrx9Ba2UBNX9hB31Omrq+QoZ2Gly0KLrQWw4Of1AQ4J9lnD+XOdwOdcdXqqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "apg-lite": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/@swc/helpers": {
@@ -2522,6 +3237,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -2545,11 +3269,26 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/prismjs": {
+      "version": "1.26.6",
+      "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.6.tgz",
+      "integrity": "sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ramda": {
+      "version": "0.30.2",
+      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.30.2.tgz",
+      "integrity": "sha512-PyzHvjCalm2BRYjAU6nIB3TprYwMNOUY/7P/N8bSzp9W/yM2YrtGtAnnVtaCNSeOZ8DzKyFDvaqQs7LnWwwmBA==",
+      "license": "MIT",
+      "dependencies": {
+        "types-ramda": "^0.30.1"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2576,6 +3315,35 @@
       "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
       "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/swagger-ui-react": {
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-react/-/swagger-ui-react-5.18.0.tgz",
+      "integrity": "sha512-c2M9adVG7t28t1pq19K9Jt20VLQf0P/fwJwnfcmsVVsdkwCWhRmbKDu+tIs0/NGwJ/7GY8lBx+iKZxuDI5gDbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/ws": {
@@ -3396,11 +4164,16 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/apg-lite": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/apg-lite/-/apg-lite-1.0.5.tgz",
+      "integrity": "sha512-SlI+nLMQDzCZfS39ihzjGp3JNBQfJXyMi6cg9tkLOCPVErgFsUIAEdO9IezR7kbP5Xd0ozcPNQBkf9TO5cHgWw==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/aria-query": {
@@ -3619,11 +4392,25 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/autolinker": {
+      "version": "3.16.2",
+      "resolved": "https://registry.npmjs.org/autolinker/-/autolinker-3.16.2.tgz",
+      "integrity": "sha512-JiYl7j2Z19F9NdTmirENSUUIIL/9MytEWtmzhfmsKPCp9E+G35Y0UNCMoM9tFigxT59qSc8Ml2dlZXOCVTYwuA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "possible-typed-array-names": "^1.0.0"
@@ -3643,6 +4430,17 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -3771,6 +4569,30 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
@@ -3781,7 +4603,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
       "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.0",
@@ -3800,7 +4621,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3814,7 +4634,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -3883,6 +4702,42 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
     },
     "node_modules/cli-width": {
       "version": "4.1.0",
@@ -3953,6 +4808,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3978,6 +4855,26 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/copy-to-clipboard": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
+      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
+      "license": "MIT",
+      "dependencies": {
+        "toggle-selection": "^1.0.6"
+      }
+    },
+    "node_modules/core-js-pure": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.49.0.tgz",
+      "integrity": "sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/cross-spawn": {
@@ -4013,14 +4910,13 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
       "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -4131,6 +5027,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -4138,11 +5056,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
@@ -4172,6 +5098,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/dequal": {
@@ -4216,11 +5151,28 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/dompurify": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/drange": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/drange/-/drange-1.1.1.tgz",
+      "integrity": "sha512-pYxfDYpued//QpnLIm4Avk7rsNtAtQkUES2cwAYSvD/wd2pKD71gN2Ebj3e7klzXwjocvE8c5vx/1fxwpqmSxA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -4354,7 +5306,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4364,7 +5315,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4410,7 +5360,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -4423,7 +5372,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4958,6 +5906,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/fast-json-patch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
+      "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==",
+      "license": "MIT"
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -4980,6 +5934,19 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fault": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
+      "integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
+      "license": "MIT",
+      "dependencies": {
+        "format": "^0.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/fetch-blob": {
@@ -5069,11 +6036,30 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
       "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.2.7"
@@ -5083,6 +6069,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
+      "engines": {
+        "node": ">=0.4.x"
       }
     },
     "node_modules/formdata-polyfill": {
@@ -5116,7 +6126,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5215,7 +6224,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -5240,7 +6248,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -5354,7 +6361,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5407,7 +6413,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
@@ -5436,7 +6441,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5449,7 +6453,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -5465,13 +6468,42 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/headers-polyfill": {
@@ -5497,6 +6529,21 @@
       "dependencies": {
         "hermes-estree": "0.25.1"
       }
+    },
+    "node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/highlightjs-vue": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/highlightjs-vue/-/highlightjs-vue-1.0.0.tgz",
+      "integrity": "sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==",
+      "license": "CC0-1.0"
     },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
@@ -5540,6 +6587,26 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -5548,6 +6615,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/immutable": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.3.tgz",
+      "integrity": "sha512-AUY/VyX0E5XlibOmWt10uabJzam1zlYjwiEgQSDc5+UIkFNaF9WM0JxXKaNMGf+F/ffUF+7kRKXM9A7C0xXqMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/import-fresh": {
@@ -5587,6 +6663,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -5600,6 +6682,39 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-array-buffer": {
@@ -5700,7 +6815,6 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5758,6 +6872,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-extglob": {
@@ -5827,6 +6951,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-map": {
@@ -5983,7 +7117,6 @@
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
       "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "which-typed-array": "^1.1.16"
@@ -6045,7 +7178,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -6122,18 +7254,22 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/js-file-download": {
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/js-file-download/-/js-file-download-0.4.12.tgz",
+      "integrity": "sha512-rML+NkoD08p5Dllpjo0ffy4jRHeY6Zsapvr/W86N7E0yuzAO6qa5X9+xog6zQNlH102J7IXljNY2FtS6Lj3ucg==",
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -6607,6 +7743,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -6624,13 +7772,26 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lowlight": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.20.0.tgz",
+      "integrity": "sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==",
+      "license": "MIT",
+      "dependencies": {
+        "fault": "^1.0.0",
+        "highlight.js": "~10.7.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/lru-cache": {
@@ -6709,7 +7870,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6746,6 +7906,27 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -6754,6 +7935,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/minim": {
+      "version": "0.23.8",
+      "resolved": "https://registry.npmjs.org/minim/-/minim-0.23.8.tgz",
+      "integrity": "sha512-bjdr2xW1dBCMsMGGsUeqM4eFI60m94+szhxWys+B1ztIt6gWSfeGBdSVCIawezeHYLYn0j6zrsXdQS/JllBzww==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.15.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/minimatch": {
@@ -6881,6 +8074,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/neotraverse": {
+      "version": "0.6.18",
+      "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.18.tgz",
+      "integrity": "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/next": {
       "version": "16.2.2",
       "resolved": "https://registry.npmjs.org/next/-/next-16.2.2.tgz",
@@ -6962,6 +8164,22 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/node-abort-controller": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
+      "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==",
+      "license": "MIT"
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.7.0.tgz",
+      "integrity": "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
     "node_modules/node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
@@ -7019,6 +8237,35 @@
         "url": "https://opencollective.com/node-fetch"
       }
     },
+    "node_modules/node-fetch-commonjs": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch-commonjs/-/node-fetch-commonjs-3.3.2.tgz",
+      "integrity": "sha512-VBlAiynj3VMLrotgwOS3OyECFxas5y7ltLcK4t41lMUZeaK15Ym4QRkqN0EQKAFL42q9i21EPKjzLUPfltR72A==",
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.37",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
@@ -7030,7 +8277,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7160,6 +8406,30 @@
       ],
       "license": "MIT"
     },
+    "node_modules/openapi-path-templating": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/openapi-path-templating/-/openapi-path-templating-2.2.1.tgz",
+      "integrity": "sha512-eN14VrDvl/YyGxxrkGOHkVkWEoPyhyeydOUrbvjoz8K5eIGgELASwN1eqFOJ2CTQMGCy2EntOK1KdtJ8ZMekcg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "apg-lite": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/openapi-server-url-templating": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/openapi-server-url-templating/-/openapi-server-url-templating-1.3.0.tgz",
+      "integrity": "sha512-DPlCms3KKEbjVQb0spV6Awfn6UWNheuG/+folQPzh/wUaKwuqvj8zt5gagD7qoyxtE03cIiKPgLFS3Q8Bz00uQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "apg-lite": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -7261,6 +8531,31 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
     "node_modules/parse5": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
@@ -7338,7 +8633,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
       "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7421,16 +8715,34 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/protobufjs": {
@@ -7457,6 +8769,15 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -7466,6 +8787,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -7488,6 +8815,54 @@
       ],
       "license": "MIT"
     },
+    "node_modules/ramda": {
+      "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.1.tgz",
+      "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ramda"
+      }
+    },
+    "node_modules/ramda-adjunct": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-5.1.0.tgz",
+      "integrity": "sha512-8qCpl2vZBXEJyNbi4zqcgdfHtcdsWjOGbiNSEnEBrM6Y0OKOT8UxJbIVGm1TIcjaSu2MxaWcgtsNlKlCk7o7qg==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ramda-adjunct"
+      },
+      "peerDependencies": {
+        "ramda": ">= 0.30.0"
+      }
+    },
+    "node_modules/randexp": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.5.3.tgz",
+      "integrity": "sha512-U+5l2KrcMNOUPYvazA3h5ekF80FHTUG+87SEAmHZmolh1M+i/WyTCxVzmi+tidIa1tM4BSe8g2Y/D3loWDjj+w==",
+      "license": "MIT",
+      "dependencies": {
+        "drange": "^1.0.2",
+        "ret": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
@@ -7509,12 +8884,77 @@
         "react": "^19.2.4"
       }
     },
+    "node_modules/react-immutable-proptypes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/react-immutable-proptypes/-/react-immutable-proptypes-2.2.0.tgz",
+      "integrity": "sha512-Vf4gBsePlwdGvSZoLSBfd4HAP93HDauMY4fDjXhreg/vg6F3Fj/MXDNyTbltPC/xZKmZc+cjLu3598DdYK6sgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.2"
+      },
+      "peerDependencies": {
+        "immutable": ">=3.6.2"
+      }
+    },
+    "node_modules/react-immutable-pure-component": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/react-immutable-pure-component/-/react-immutable-pure-component-2.2.2.tgz",
+      "integrity": "sha512-vkgoMJUDqHZfXXnjVlG3keCxSO/U6WeDQ5/Sl0GK2cH8TOxEzQ5jXqDXHEL/jqk6fsNxV05oH5kD7VNMUE2k+A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "immutable": ">= 2 || >= 4.0.0-rc",
+        "react": ">= 16.6",
+        "react-dom": ">= 16.6"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-syntax-highlighter": {
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-16.1.1.tgz",
+      "integrity": "sha512-PjVawBGy80C6YbC5DDZJeUjBmC7skaoEUdvfFQediQHgCL7aKyVHe57SaJGfQsloGDac+gCpTfRdtxzWWKmCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.4",
+        "highlight.js": "^10.4.1",
+        "highlightjs-vue": "^1.0.0",
+        "lowlight": "^1.17.0",
+        "prismjs": "^1.30.0",
+        "refractor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 16.20.2"
+      },
+      "peerDependencies": {
+        "react": ">= 0.14.0"
+      }
     },
     "node_modules/redent": {
       "version": "3.0.0",
@@ -7528,6 +8968,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-immutable": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/redux-immutable/-/redux-immutable-4.0.0.tgz",
+      "integrity": "sha512-SchSn/DWfGb3oAejd+1hhHx01xUoxY+V7TeK0BKqpkLKiQPVFf7DYzEaKmrEVxsWxielKfSK9/Xq66YyxgR1cg==",
+      "license": "BSD-3-Clause",
+      "peerDependencies": {
+        "immutable": "^3.8.1 || ^4.0.0-rc.1"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -7553,6 +9008,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/refractor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/refractor/-/refractor-5.0.0.tgz",
+      "integrity": "sha512-QXOrHQF5jOpjjLfiNk5GFnWhRXvxjUVnlFxkeDmewR5sXkr3iM46Zo+CnRR8B+MDVqkULW4EcLVcRBNOPXHosw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/prismjs": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "parse-entities": "^4.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -7574,6 +9045,40 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/remarkable": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/remarkable/-/remarkable-2.0.1.tgz",
+      "integrity": "sha512-YJyMcOH5lrR+kZdmB0aJJ4+93bEojRZ1HGDn9Eagu6ibg7aVZhc3OWbbShRid+Q5eAfsEqWxpe+g5W5nYNfNiA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.10",
+        "autolinker": "^3.11.0"
+      },
+      "bin": {
+        "remarkable": "bin/remarkable.js"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/remarkable/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -7593,6 +9098,18 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "2.0.0-next.6",
@@ -7636,6 +9153,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/ret": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
+      "integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/retry": {
@@ -7834,11 +9360,37 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/serialize-error": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.1.0.tgz",
+      "integrity": "sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/serialize-error/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
@@ -7881,6 +9433,26 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/sha.js": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+      "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
+      "license": "(MIT AND BSD-3-Clause)",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.0"
+      },
+      "bin": {
+        "sha.js": "bin.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/sharp": {
@@ -7962,6 +9534,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/short-unique-id": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/short-unique-id/-/short-unique-id-5.3.2.tgz",
+      "integrity": "sha512-KRT/hufMSxXKEDSQujfVE0Faa/kZ51ihUcZQAcmP04t00DvPj7Ox5anHke1sJYUtzSuiT/Y5uyzg/W7bBEGhCg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "short-unique-id": "bin/short-unique-id",
+        "suid": "bin/short-unique-id"
       }
     },
     "node_modules/side-channel": {
@@ -8068,6 +9650,22 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/stable-hash": {
       "version": "0.0.5",
@@ -8354,6 +9952,114 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swagger-client": {
+      "version": "3.37.2",
+      "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.37.2.tgz",
+      "integrity": "sha512-KcB8psL1On4GWwv9Ribp1oteh50ygNnAyvQbd5MwiXMGkcB4f53rkZEdvZKPDdJO764mQjgErxQEGDVw6QBUMQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.22.15",
+        "@scarf/scarf": "=1.4.0",
+        "@swagger-api/apidom-core": "^1.10.2",
+        "@swagger-api/apidom-error": "^1.10.2",
+        "@swagger-api/apidom-json-pointer": "^1.10.2",
+        "@swagger-api/apidom-ns-openapi-3-1": "^1.10.2",
+        "@swagger-api/apidom-ns-openapi-3-2": "^1.10.2",
+        "@swagger-api/apidom-reference": "^1.10.2",
+        "@swaggerexpert/cookie": "^2.0.2",
+        "deepmerge": "~4.3.0",
+        "fast-json-patch": "^3.0.0-1",
+        "js-yaml": "^4.1.0",
+        "neotraverse": "=0.6.18",
+        "node-abort-controller": "^3.1.1",
+        "node-fetch-commonjs": "^3.3.2",
+        "openapi-path-templating": "^2.2.1",
+        "openapi-server-url-templating": "^1.3.0",
+        "ramda": "^0.30.1",
+        "ramda-adjunct": "^5.1.0"
+      }
+    },
+    "node_modules/swagger-ui-react": {
+      "version": "5.32.4",
+      "resolved": "https://registry.npmjs.org/swagger-ui-react/-/swagger-ui-react-5.32.4.tgz",
+      "integrity": "sha512-OsTqKCiDT/o8/oqZbt+p1djPkrOk3unKK/7+wGvP1+WY6pOzFoDLM4D39cNFtpIArtlg9uoK6MKIz3W00WX8qw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.27.1",
+        "@scarf/scarf": "=1.4.0",
+        "base64-js": "^1.5.1",
+        "buffer": "^6.0.3",
+        "classnames": "^2.5.1",
+        "css.escape": "1.5.1",
+        "deep-extend": "0.6.0",
+        "dompurify": "^3.3.2",
+        "ieee754": "^1.2.1",
+        "immutable": "^3.x.x",
+        "js-file-download": "^0.4.12",
+        "js-yaml": "=4.1.1",
+        "lodash": "^4.18.1",
+        "prop-types": "^15.8.1",
+        "randexp": "^0.5.3",
+        "randombytes": "^2.1.0",
+        "react-copy-to-clipboard": "5.1.0",
+        "react-debounce-input": "=3.3.0",
+        "react-immutable-proptypes": "2.2.0",
+        "react-immutable-pure-component": "^2.2.0",
+        "react-inspector": "^6.0.1",
+        "react-redux": "^9.2.0",
+        "react-syntax-highlighter": "^16.0.0",
+        "redux": "^5.0.1",
+        "redux-immutable": "^4.0.0",
+        "remarkable": "^2.0.1",
+        "reselect": "^5.1.1",
+        "serialize-error": "^8.1.0",
+        "sha.js": "^2.4.12",
+        "swagger-client": "^3.37.2",
+        "url-parse": "^1.5.10",
+        "xml": "=1.0.1",
+        "xml-but-prettier": "^1.0.1",
+        "zenscroll": "^4.0.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 <20",
+        "react-dom": ">=16.8.0 <20"
+      }
+    },
+    "node_modules/swagger-ui-react/node_modules/react-copy-to-clipboard": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/react-copy-to-clipboard/-/react-copy-to-clipboard-5.1.0.tgz",
+      "integrity": "sha512-k61RsNgAayIJNoy9yDsYzDe/yAZAzEbEgcz3DZMhF686LEyukcE1hzurxe85JandPUG+yTfGVFzuEw3xt8WP/A==",
+      "license": "MIT",
+      "dependencies": {
+        "copy-to-clipboard": "^3.3.1",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": "^15.3.0 || 16 || 17 || 18"
+      }
+    },
+    "node_modules/swagger-ui-react/node_modules/react-debounce-input": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/react-debounce-input/-/react-debounce-input-3.3.0.tgz",
+      "integrity": "sha512-VEqkvs8JvY/IIZvh71Z0TC+mdbxERvYF33RcebnodlsUZ8RSgyKe2VWaHXv4+/8aoOgXLxWrdsYs2hDhcwbUgA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.debounce": "^4",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": "^15.3.0 || 16 || 17 || 18"
+      }
+    },
+    "node_modules/swagger-ui-react/node_modules/react-inspector": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/react-inspector/-/react-inspector-6.0.2.tgz",
+      "integrity": "sha512-x+b7LxhmHXjHoU/VrFAzw5iutsILRoYyDq97EDYdFpPLcvqtEzk4ZSZSQjnFPbr5T57tLXnHcqFYoN1pI6u8uQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -8490,6 +10196,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/to-buffer": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "^2.0.5",
+        "safe-buffer": "^5.2.1",
+        "typed-array-buffer": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -8502,6 +10222,12 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==",
+      "license": "MIT"
     },
     "node_modules/tough-cookie": {
       "version": "6.0.1",
@@ -8529,6 +10255,38 @@
         "node": ">=20"
       }
     },
+    "node_modules/tree-sitter": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.21.1.tgz",
+      "integrity": "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^8.0.0",
+        "node-gyp-build": "^4.8.0"
+      }
+    },
+    "node_modules/tree-sitter-json": {
+      "version": "0.24.8",
+      "resolved": "https://registry.npmjs.org/tree-sitter-json/-/tree-sitter-json-0.24.8.tgz",
+      "integrity": "sha512-Tc9ZZYwHyWZ3Tt1VEw7Pa2scu1YO7/d2BCBbKTx5hXwig3UfdQjsOPkPyLpDJOn/m1UBEWYAtSdGAwCSyagBqQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -8541,6 +10299,18 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/ts-mixer": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
+      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
+      "license": "MIT"
+    },
+    "node_modules/ts-toolbelt": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
+      "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==",
+      "license": "Apache-2.0"
     },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
@@ -8607,7 +10377,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
       "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -8681,6 +10450,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/types-ramda": {
+      "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/types-ramda/-/types-ramda-0.30.1.tgz",
+      "integrity": "sha512-1HTsf5/QVRmLzcGfldPFvkVsAdi1db1BBKzi7iW3KBUlOICg/nKnFS+jGqDJS3YD8VsWbAh7JiHeBvbsw8RPxA==",
+      "license": "MIT",
+      "dependencies": {
+        "ts-toolbelt": "^9.6.0"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -8752,6 +10530,12 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/unraw": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unraw/-/unraw-3.0.0.tgz",
+      "integrity": "sha512-08/DA66UF65OlpUDIQtbJyrqTR0jTAlJ+jsnkQ4jxR7+K5g5YG1APZKQSMCE1vqqmD+2pv6+IdEjmopFatacvg==",
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {
@@ -8838,6 +10622,25 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/vite": {
@@ -9056,6 +10859,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/web-tree-sitter": {
+      "version": "0.24.5",
+      "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.24.5.tgz",
+      "integrity": "sha512-+J/2VSHN8J47gQUAvF8KDadrfz6uFYVjxoxbKWDoXVsH2u7yLdarCnIURnrMA6uSRkgX3SdmqM5BOoQjPdSh5w==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/webidl-conversions": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
@@ -9178,7 +10988,6 @@
       "version": "1.1.20",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
       "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
@@ -9257,6 +11066,21 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
+      "license": "MIT"
+    },
+    "node_modules/xml-but-prettier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml-but-prettier/-/xml-but-prettier-1.0.1.tgz",
+      "integrity": "sha512-C2CJaadHrZTqESlH03WOyw0oZTtoy2uEg6dSDF6YRg+9GnYNub53RRemLpnvtbHDFelxMx4LajiFsYeR6XJHgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "repeat-string": "^1.5.2"
       }
     },
     "node_modules/xml-name-validator": {
@@ -9347,6 +11171,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/zenscroll": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zenscroll/-/zenscroll-4.0.2.tgz",
+      "integrity": "sha512-jEA1znR7b4C/NnaycInCU6h/d15ZzCd1jmsruqOKnZP6WXQSMH3W2GL+OXbkruslU4h+Tzuos0HdswzRUk/Vgg==",
+      "license": "Unlicense"
     },
     "node_modules/zod": {
       "version": "4.3.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "comicly",
       "version": "0.1.0",
       "dependencies": {
+        "@google/genai": "^1.50.1",
         "@supabase/ssr": "^0.10.2",
         "@supabase/supabase-js": "^2.103.3",
         "next": "16.2.2",
@@ -696,6 +697,29 @@
       },
       "peerDependenciesMeta": {
         "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@google/genai": {
+      "version": "1.50.1",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.50.1.tgz",
+      "integrity": "sha512-YbkX7H9+1Pt8wOt7DDREy8XSoiL6fRDzZQRyaVBarFf8MR3zHGqVdvM4cLbDXqPhxqvegZShgfxb8kw9C7YhAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
           "optional": true
         }
       }
@@ -1614,6 +1638,70 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.15",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
@@ -2477,6 +2565,12 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
     "node_modules/@types/statuses": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
@@ -3250,6 +3344,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -3559,6 +3662,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.15",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.15.tgz",
@@ -3579,6 +3702,15 @@
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/brace-expansion": {
@@ -3638,6 +3770,12 @@
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/call-bind": {
       "version": "1.0.8",
@@ -3892,6 +4030,15 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/data-urls": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
@@ -3964,7 +4111,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4083,6 +4229,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -4760,6 +4915,12 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4819,6 +4980,29 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/file-entry-cache": {
@@ -4901,6 +5085,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -4955,6 +5151,34 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/generator-function": {
@@ -5098,6 +5322,32 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/gopd": {
@@ -5267,6 +5517,19 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/iceberg-js": {
       "version": "0.8.1",
@@ -5943,6 +6206,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -5991,6 +6263,27 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/keyv": {
@@ -6321,6 +6614,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -6484,7 +6783,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/msw": {
@@ -6664,6 +6962,26 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
@@ -6681,6 +6999,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/node-releases": {
@@ -6899,6 +7235,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7084,6 +7433,30 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -7265,6 +7638,15 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/rettime": {
       "version": "0.11.7",
       "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.11.7.tgz",
@@ -7367,6 +7749,26 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
@@ -8643,6 +9045,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "comicly",
       "version": "0.1.0",
       "dependencies": {
+        "@supabase/ssr": "^0.10.2",
+        "@supabase/supabase-js": "^2.103.3",
         "next": "16.2.2",
         "react": "19.2.4",
         "react-dom": "19.2.4"
@@ -1909,6 +1911,104 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.103.3",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.103.3.tgz",
+      "integrity": "sha512-SMDJ4vg5jLXNEHdhN4J4ujSb203WangbDw1n3VaARH0ZqM51E6lJnoUAHlpQU9N7SzP0hfgghA9IvT8c7tGRfg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.103.3",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.103.3.tgz",
+      "integrity": "sha512-A2ZHi95GIRRlN9LGOSa/zGEIPg9taR1giDI9Gkfkgrcz0YmKV8ShiAplIrKsHQFdkzKxtsO3maJF0efL+i31mg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.0.tgz",
+      "integrity": "sha512-RHSx8bHS02xwfHdAbX5Lpbo6PXbgyf7lTaXTlwtFDPwOIw64NnVRwFAXGojHhjtVYI+PEPNSWwkL90f4agN3bw==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.103.3",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.103.3.tgz",
+      "integrity": "sha512-S0k/9FJVXDeejNfQLCJwRlm4IH8Wet/HEEdBTBpX6/G2o1eU/6CjQop/hJPZIwlQkI6D/zbHH8KymuCsBgy6jA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.103.3",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.103.3.tgz",
+      "integrity": "sha512-fUvKtSXMUk1BkApVwAurWtHF4Vzbb0UB9aC/fQXrRBek7Ta3Kaora+wHf/fGwFNQs7uRz+mvjIVpzLfpR32VXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "^0.4.0",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/ssr": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.10.2.tgz",
+      "integrity": "sha512-JFbchN63CXLFHJRNT7udec4/RoD9PmXkSGko3QSO6vUuqGBtSzdmxR7FPfQNr7SuFd65I7Xv46q66ALjEN1cgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.2"
+      },
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.102.1"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.103.3",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.103.3.tgz",
+      "integrity": "sha512-5bAIEubrw5keHcdKR2RTois0O1M2Ilx4UYuzOzc07G6mLGCPS/8t1nbC6Vq451pnxR3sK+rmtFHWb9CY/OPjAw==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.103.3",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.103.3.tgz",
+      "integrity": "sha512-DuPiAz5pIJsTAQCt7B6bDZrnLzlq9+/5bta/GWTsgpLn6AkuZQcmYsQHYplv4skQ8U2raKY5HASQOu4KtYq9Qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.103.3",
+        "@supabase/functions-js": "2.103.3",
+        "@supabase/postgrest-js": "2.103.3",
+        "@supabase/realtime-js": "2.103.3",
+        "@supabase/storage-js": "2.103.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -2352,7 +2452,6 @@
       "version": "20.19.39",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
       "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2384,6 +2483,15 @@
       "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.58.0",
@@ -3725,7 +3833,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
       "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -5160,6 +5267,15 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -8234,7 +8350,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {
@@ -8710,6 +8825,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "@supabase/supabase-js": "^2.103.3",
     "next": "16.2.2",
     "react": "19.2.4",
-    "react-dom": "19.2.4"
+    "react-dom": "19.2.4",
+    "swagger-ui-react": "^5.32.4"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
@@ -26,6 +27,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/swagger-ui-react": "^5.18.0",
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/coverage-v8": "^4.1.4",
     "eslint": "^9",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@supabase/ssr": "^0.10.2",
+    "@supabase/supabase-js": "^2.103.3",
     "next": "16.2.2",
     "react": "19.2.4",
     "react-dom": "19.2.4"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@google/genai": "^1.50.1",
     "@supabase/ssr": "^0.10.2",
     "@supabase/supabase-js": "^2.103.3",
     "next": "16.2.2",

--- a/src/app/api/CLAUDE.md
+++ b/src/app/api/CLAUDE.md
@@ -84,7 +84,8 @@ All business logic lives in `src/backend/`. See `src/backend/CLAUDE.md` for conv
 1. Implement one GitHub issue completely.
 2. Stop and summarise what was built. Wait for Reghu's explicit confirmation.
 3. Only after confirmation: commit all changes for that issue.
-4. Only after committing: move to the next issue. Do not chain issues autonomously.
+4. Push the branch to remote.
+5. Only after pushing: move to the next issue. Do not chain issues autonomously.
 
 ### Commit After Each Approved Issue
 - Commit message must reference the issue number: `feat(backend): ... (#<issue-number>)`

--- a/src/app/api/CLAUDE.md
+++ b/src/app/api/CLAUDE.md
@@ -1,0 +1,99 @@
+# API Routes — CLAUDE.md
+
+This directory contains **only** thin Next.js route handlers. No business logic here.
+
+## The Pattern
+
+```typescript
+import { NextRequest, NextResponse } from "next/server";
+import { myHandler } from "@/backend/handlers/my-handler";
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  const result = await myHandler(body);
+  return NextResponse.json(result, { status: 201 });
+}
+```
+
+Each route file does exactly three things:
+1. Parse the request (`req.json()`, `req.nextUrl.searchParams`, `params`)
+2. Call one handler from `src/backend/handlers/`
+3. Return a `NextResponse`
+
+## Error Handling
+
+Catch errors from the handler and return the standard error shape:
+
+```typescript
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const result = await myHandler(body);
+    return NextResponse.json(result, { status: 201 });
+  } catch (err) {
+    if (err instanceof Error && err.message === "AUTH_REQUIRED") {
+      return NextResponse.json({ error: "Authentication required" }, { status: 401 });
+    }
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+```
+
+## Long-Running Routes
+
+For the `generate-all` route, export a max duration at the top of the file:
+
+```typescript
+export const maxDuration = 300; // requires Vercel Pro
+```
+
+## Route Map
+
+```
+api/comic/route.ts                        POST   create comic
+api/comic/random-idea/route.ts            GET    random idea
+api/comic/[id]/route.ts                   GET    get comic  |  DELETE  delete comic
+api/comic/[id]/refine/route.ts            POST   submit follow-up answers
+api/comic/[id]/script/generate/route.ts   POST   generate script
+api/comic/[id]/script/regenerate/route.ts POST   regenerate script
+api/comic/[id]/approve/route.ts           PUT    approve script + set mode
+api/comic/[id]/generate-all/route.ts      POST   automated image generation
+api/comic/[id]/page/generate/route.ts     POST   generate single page
+api/comic/[id]/page/regenerate/route.ts   POST   regenerate a page
+api/comic/[id]/page/select/route.ts       PUT    select page version
+```
+
+## Business Logic
+
+All business logic lives in `src/backend/`. See `src/backend/CLAUDE.md` for conventions.
+
+---
+
+## Working Preferences
+
+### PRD Is the Source of Truth
+- Only create routes listed in `references/comicly-technical-prd.md` Section 6.
+- **⚠️ If anything needs to deviate from the PRD contract (method, path, request/response shape), STOP and flag it before proceeding.**
+- **⚠️ If a route's contract is unclear, ASK before implementing. Do not guess.**
+
+### Scope — Backend Only
+- Reghu owns backend only. Do not touch frontend code.
+- Work is structured issue by issue (GitHub issues #9–#34 are Reghu's backend issues).
+
+### Issue-by-Issue Workflow
+1. Implement one GitHub issue completely.
+2. Stop and summarise what was built. Wait for Reghu's explicit confirmation.
+3. Only after confirmation: commit all changes for that issue.
+4. Only after committing: move to the next issue. Do not chain issues autonomously.
+
+### Commit After Each Approved Issue
+- Commit message must reference the issue number: `feat(backend): ... (#<issue-number>)`
+- Do not commit until Reghu explicitly approves the implementation.
+
+### Code Quality
+- All code must be TypeScript. No `.js` files.
+- Never use `any`. Every request body and response must have an explicit type.
+- Run `npm run lint` before considering any route done.
+
+### Every Route Must Be Complete
+- Every route must handle all outcomes: success, validation error, auth error (401/403), not found (404), and unexpected error (500). No partial error handling.

--- a/src/app/api/CLAUDE.md
+++ b/src/app/api/CLAUDE.md
@@ -81,11 +81,12 @@ All business logic lives in `src/backend/`. See `src/backend/CLAUDE.md` for conv
 - Work is structured issue by issue (GitHub issues #9–#34 are Reghu's backend issues).
 
 ### Issue-by-Issue Workflow
-1. Implement one GitHub issue completely.
-2. Stop and summarise what was built. Wait for Reghu's explicit confirmation.
-3. Only after confirmation: commit all changes for that issue.
-4. Push the branch to remote.
-5. Only after pushing: move to the next issue. Do not chain issues autonomously.
+1. Before starting an issue: create the branch, then brief Reghu on what will be built (files, functions, tests). Wait for his explicit go-ahead before writing any code.
+2. Implement the issue completely.
+3. Stop and summarise what was built. Wait for Reghu's explicit confirmation.
+4. Only after confirmation: commit all changes for that issue.
+5. Push the branch to remote.
+6. Only after pushing: move to the next issue. Do not chain issues autonomously.
 
 ### Commit After Each Approved Issue
 - Commit message must reference the issue number: `feat(backend): ... (#<issue-number>)`

--- a/src/app/api/comic/[id]/approve/route.ts
+++ b/src/app/api/comic/[id]/approve/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from "next/server";
+import { approveComic } from "@/backend/handlers/approve-comic";
+
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const body = await req.json();
+    const result = await approveComic(id, body);
+    return NextResponse.json(result, { status: 200 });
+  } catch (err) {
+    if (err instanceof Error) {
+      if (err.message.startsWith("INVALID_INPUT:")) {
+        return NextResponse.json({ error: err.message.replace("INVALID_INPUT: ", "") }, { status: 400 });
+      }
+      if (err.message.startsWith("STATUS_ERROR:")) {
+        return NextResponse.json({ error: err.message.replace("STATUS_ERROR: ", "") }, { status: 400 });
+      }
+      if (err.message.startsWith("NOT_FOUND:")) {
+        return NextResponse.json({ error: "Comic not found" }, { status: 404 });
+      }
+    }
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/comic/[id]/refine/route.ts
+++ b/src/app/api/comic/[id]/refine/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from "next/server";
+import { refineComic } from "@/backend/handlers/refine-comic";
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const body = await req.json();
+    const result = await refineComic(id, body);
+    return NextResponse.json(result, { status: 200 });
+  } catch (err) {
+    if (err instanceof Error) {
+      if (err.message.startsWith("INVALID_INPUT:")) {
+        return NextResponse.json({ error: err.message.replace("INVALID_INPUT: ", "") }, { status: 400 });
+      }
+      if (err.message.startsWith("STATUS_ERROR:")) {
+        return NextResponse.json({ error: err.message.replace("STATUS_ERROR: ", "") }, { status: 400 });
+      }
+      if (err.message.startsWith("NOT_FOUND:")) {
+        return NextResponse.json({ error: "Comic not found" }, { status: 404 });
+      }
+    }
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/comic/[id]/route.ts
+++ b/src/app/api/comic/[id]/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getComic } from "@/backend/handlers/get-comic";
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const result = await getComic(id);
+    return NextResponse.json(result, { status: 200 });
+  } catch (err) {
+    if (err instanceof Error && err.message.startsWith("NOT_FOUND:")) {
+      return NextResponse.json({ error: "Comic not found" }, { status: 404 });
+    }
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/comic/[id]/script/generate/route.ts
+++ b/src/app/api/comic/[id]/script/generate/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server";
+import { generateComicScript } from "@/backend/handlers/generate-script";
+
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const result = await generateComicScript(id);
+    return NextResponse.json(result, { status: 200 });
+  } catch (err) {
+    if (err instanceof Error) {
+      if (err.message.startsWith("STATUS_ERROR:")) {
+        return NextResponse.json({ error: err.message.replace("STATUS_ERROR: ", "") }, { status: 400 });
+      }
+      if (err.message.startsWith("NOT_FOUND:")) {
+        return NextResponse.json({ error: "Comic not found" }, { status: 404 });
+      }
+    }
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/comic/random-idea/route.ts
+++ b/src/app/api/comic/random-idea/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from "next/server";
+import { randomIdea } from "@/backend/handlers/random-idea";
+
+export async function GET() {
+  try {
+    const result = await randomIdea();
+    return NextResponse.json(result, { status: 200 });
+  } catch {
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/comic/route.ts
+++ b/src/app/api/comic/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createComic } from "@/backend/handlers/create-comic";
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const result = await createComic(body);
+    return NextResponse.json(result, { status: 201 });
+  } catch (err) {
+    if (err instanceof Error) {
+      if (err.message.startsWith("INVALID_INPUT:")) {
+        return NextResponse.json(
+          { error: err.message.replace("INVALID_INPUT: ", "") },
+          { status: 400 }
+        );
+      }
+      if (err.message === "AUTH_REQUIRED") {
+        return NextResponse.json({ error: "Authentication required" }, { status: 401 });
+      }
+    }
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/docs/route.ts
+++ b/src/app/api/docs/route.ts
@@ -64,6 +64,90 @@ const spec = {
         },
       },
     },
+    "/api/comic/{id}": {
+      get: {
+        summary: "Get comic",
+        description: "Returns the full comic object. No auth required.",
+        tags: ["Comic"],
+        parameters: [{ name: "id", in: "path", required: true, schema: { type: "string", format: "uuid" } }],
+        responses: {
+          "200": { description: "Comic object", content: { "application/json": { schema: { type: "object", properties: { comic: { type: "object" } } } } } },
+          "404": { description: "Comic not found" },
+          "500": { description: "Internal server error" },
+        },
+      },
+    },
+    "/api/comic/{id}/refine": {
+      post: {
+        summary: "Submit follow-up answers",
+        description: "Stores answers and transitions status to script_pending",
+        tags: ["Comic"],
+        parameters: [{ name: "id", in: "path", required: true, schema: { type: "string", format: "uuid" } }],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["answers"],
+                properties: {
+                  answers: { type: "object", additionalProperties: { type: "string" }, example: { q1: "Inspector Whiskers", q3: "A stolen diamond" } },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          "200": { description: "Answers stored", content: { "application/json": { schema: { type: "object", properties: { success: { type: "boolean" } } } } } },
+          "400": { description: "Validation or status error" },
+          "404": { description: "Comic not found" },
+          "500": { description: "Internal server error" },
+        },
+      },
+    },
+    "/api/comic/{id}/script/generate": {
+      post: {
+        summary: "Generate script",
+        description: "Generates full comic script via Gemini. Transitions status to script_draft.",
+        tags: ["Script"],
+        parameters: [{ name: "id", in: "path", required: true, schema: { type: "string", format: "uuid" } }],
+        responses: {
+          "200": { description: "Script generated", content: { "application/json": { schema: { type: "object", properties: { script: { type: "object" } } } } } },
+          "400": { description: "Status error" },
+          "404": { description: "Comic not found" },
+          "500": { description: "Internal server error" },
+        },
+      },
+    },
+    "/api/comic/{id}/approve": {
+      put: {
+        summary: "Approve script",
+        description: "Validates and stores the approved script and generation mode. Transitions status to script_approved.",
+        tags: ["Script"],
+        parameters: [{ name: "id", in: "path", required: true, schema: { type: "string", format: "uuid" } }],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["script", "generationMode"],
+                properties: {
+                  script: { type: "object" },
+                  generationMode: { type: "string", enum: ["supervised", "automated"] },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          "200": { description: "Script approved", content: { "application/json": { schema: { type: "object", properties: { success: { type: "boolean" } } } } } },
+          "400": { description: "Validation or status error" },
+          "404": { description: "Comic not found" },
+          "500": { description: "Internal server error" },
+        },
+      },
+    },
     "/api/comic/random-idea": {
       get: {
         summary: "Generate random idea",

--- a/src/app/api/docs/route.ts
+++ b/src/app/api/docs/route.ts
@@ -1,0 +1,95 @@
+import { NextResponse } from "next/server";
+
+const spec = {
+  openapi: "3.0.0",
+  info: {
+    title: "Comicly API",
+    version: "1.0.0",
+    description: "Backend API for the Comicly comic generation app",
+  },
+  servers: [{ url: process.env.NEXT_PUBLIC_BASE_URL ?? "http://localhost:3000" }],
+  paths: {
+    "/api/comic": {
+      post: {
+        summary: "Create comic",
+        description: "Creates a new comic and generates follow-up questions via Gemini",
+        tags: ["Comic"],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["prompt", "artStyle", "pageCount"],
+                properties: {
+                  prompt: { type: "string", example: "A detective cat solves mysteries in a steampunk city" },
+                  artStyle: {
+                    type: "string",
+                    enum: ["manga", "western_comic", "watercolor_storybook", "minimalist_flat", "vintage_newspaper", "custom"],
+                    example: "manga",
+                  },
+                  customStylePrompt: { type: "string", nullable: true, example: null },
+                  pageCount: { type: "integer", minimum: 1, maximum: 15, example: 5 },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          "201": {
+            description: "Comic created",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    comicId: { type: "string", format: "uuid" },
+                    followUpQuestions: {
+                      type: "array",
+                      items: {
+                        type: "object",
+                        properties: {
+                          id: { type: "string", example: "q1" },
+                          question: { type: "string" },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          "400": { description: "Validation error", content: { "application/json": { schema: { type: "object", properties: { error: { type: "string" } } } } } },
+          "500": { description: "Internal server error" },
+        },
+      },
+    },
+    "/api/comic/random-idea": {
+      get: {
+        summary: "Generate random idea",
+        description: "Returns a random one-sentence comic premise from Gemini",
+        tags: ["Comic"],
+        responses: {
+          "200": {
+            description: "Random idea",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    idea: { type: "string", example: "A retired astronaut opens a bakery on Mars." },
+                  },
+                },
+              },
+            },
+          },
+          "500": { description: "Internal server error" },
+        },
+      },
+    },
+  },
+};
+
+export function GET() {
+  return NextResponse.json(spec);
+}

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import "swagger-ui-react/swagger-ui.css";
+
+const SwaggerUI = dynamic(() => import("swagger-ui-react"), { ssr: false });
+
+export default function DocsPage() {
+  return (
+    <div style={{ padding: "0 1rem" }}>
+      <SwaggerUI url="/api/docs" />
+    </div>
+  );
+}

--- a/src/backend/CLAUDE.md
+++ b/src/backend/CLAUDE.md
@@ -207,11 +207,12 @@ Branch naming: `reghu/<feature-slug>` — one branch per issue, merge to `main` 
 - Work is structured issue by issue (GitHub issues #9–#34 are Reghu's backend issues).
 
 ### Issue-by-Issue Workflow
-1. Implement one GitHub issue completely.
-2. Stop and summarise what was built. Wait for Reghu's explicit confirmation.
-3. Only after confirmation: commit all changes for that issue.
-4. Push the branch to remote.
-5. Only after pushing: move to the next issue. Do not chain issues autonomously.
+1. Before starting an issue: create the branch, then brief Reghu on what will be built (files, functions, tests). Wait for his explicit go-ahead before writing any code.
+2. Implement the issue completely.
+3. Stop and summarise what was built. Wait for Reghu's explicit confirmation.
+4. Only after confirmation: commit all changes for that issue.
+5. Push the branch to remote.
+6. Only after pushing: move to the next issue. Do not chain issues autonomously.
 
 ### Commit After Each Approved Issue
 - Commit message must reference the issue number: `feat(backend): ... (#<issue-number>)`

--- a/src/backend/CLAUDE.md
+++ b/src/backend/CLAUDE.md
@@ -210,7 +210,8 @@ Branch naming: `reghu/<feature-slug>` — one branch per issue, merge to `main` 
 1. Implement one GitHub issue completely.
 2. Stop and summarise what was built. Wait for Reghu's explicit confirmation.
 3. Only after confirmation: commit all changes for that issue.
-4. Only after committing: move to the next issue. Do not chain issues autonomously.
+4. Push the branch to remote.
+5. Only after pushing: move to the next issue. Do not chain issues autonomously.
 
 ### Commit After Each Approved Issue
 - Commit message must reference the issue number: `feat(backend): ... (#<issue-number>)`

--- a/src/backend/CLAUDE.md
+++ b/src/backend/CLAUDE.md
@@ -1,0 +1,229 @@
+# Backend — CLAUDE.md
+
+Owner: **Reghu**. This directory (`src/backend/`) contains all server-side logic for Comicly. The only other backend files are the thin route handlers in `src/app/api/`.
+
+---
+
+## The One Rule: Thin Routes
+
+`src/app/api/` files contain **no business logic**. They receive the request, call one handler function, and return the response. All logic lives in `src/backend/handlers/`.
+
+```typescript
+// src/app/api/comic/route.ts  — CORRECT
+import { NextRequest, NextResponse } from "next/server";
+import { createComic } from "@/backend/handlers/create-comic";
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  const result = await createComic(body);
+  return NextResponse.json(result, { status: 201 });
+}
+```
+
+```typescript
+// src/app/api/comic/route.ts  — WRONG: logic in the route file
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  const comic = await supabase.from("comics").insert({ ... }); // ❌
+  ...
+}
+```
+
+---
+
+## Directory Structure
+
+```
+src/backend/
+├── lib/
+│   ├── types.ts              # Canonical types — shared contract with frontend
+│   ├── constants.ts          # MAX_PAGES, art style presets, image config
+│   ├── db.ts                 # All DB query functions (uses supabaseAdmin)
+│   ├── supabase/
+│   │   ├── server.ts         # createRequestClient() + supabaseAdmin
+│   │   ├── middleware.ts     # getOptionalUser() + getRequiredUser()
+│   │   └── storage.ts        # uploadImage(), deleteComicImages()
+│   └── ai/
+│       ├── gemini-client.ts  # GoogleGenAI singleton
+│       ├── prompts.ts        # All prompt template functions
+│       ├── script-generator.ts
+│       └── image-generator.ts
+└── handlers/                 # One file per route group
+    ├── create-comic.ts
+    ├── get-comic.ts
+    ├── random-idea.ts
+    ├── refine-comic.ts
+    ├── generate-script.ts
+    ├── regenerate-script.ts
+    ├── approve-comic.ts
+    ├── generate-all.ts
+    ├── generate-page.ts
+    ├── regenerate-page.ts
+    ├── select-page.ts
+    ├── delete-comic.ts
+    └── get-library.ts
+```
+
+---
+
+## Supabase Clients — Which to Use When
+
+| Situation | Client | Why |
+|-----------|--------|-----|
+| Any write to DB (insert, update, upsert, delete) | `supabaseAdmin` | Bypasses RLS; backend owns all writes |
+| Reading the authenticated user from a request | `createRequestClient()` | Reads session cookie from the incoming request |
+| Reading DB data in a handler | `supabaseAdmin` | Simpler; RLS is permissive for reads anyway |
+
+Never use `supabaseAdmin` on the client side. Never use `createBrowserClient` in backend code.
+
+---
+
+## Auth Helpers
+
+```typescript
+import { getOptionalUser, getRequiredUser } from "@/backend/lib/supabase/middleware";
+
+// Returns the user or null — for routes that work with or without auth
+const user = await getOptionalUser();
+
+// Returns the user or throws "AUTH_REQUIRED" — for protected routes
+const user = await getRequiredUser();
+```
+
+**Which routes require auth:**
+
+| Route | Auth |
+|-------|------|
+| Create comic, all pipeline steps, view comic | Optional (`getOptionalUser`) |
+| Get library | Required |
+| Delete comic | Required + ownership check |
+
+---
+
+## Types Contract
+
+`src/backend/lib/types.ts` is the **source of truth**. The frontend mirrors it in `src/frontend/lib/types.ts`. If you change the backend types, tell Qingyang so the frontend mirror stays in sync.
+
+**Import types in handler/lib code from:**
+```typescript
+import type { Comic, ComicStatus, Script } from "@/backend/lib/types";
+```
+
+---
+
+## AI Output — Always Validate
+
+Gemini text calls return JSON. Never trust the raw output:
+
+1. Use `JSON.parse()` inside a `try/catch`.
+2. On parse failure, retry once with a correction prompt ("Your previous response was not valid JSON...").
+3. After parsing, validate the structure (correct page count, panel count, required fields) before saving to DB.
+
+---
+
+## Environment Variables
+
+| Variable | Where it's safe |
+|----------|----------------|
+| `GEMINI_API_KEY` | Server-side only. Never in client components. |
+| `SUPABASE_SERVICE_ROLE_KEY` | Server-side only. Never in client components. |
+| `NEXT_PUBLIC_SUPABASE_URL` | Safe everywhere |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Safe everywhere |
+| `NEXT_PUBLIC_BASE_URL` | Safe everywhere |
+
+Any variable without `NEXT_PUBLIC_` is automatically server-only in Next.js. Keep it that way.
+
+---
+
+## Adding a New Route — Checklist
+
+1. Create `src/backend/handlers/<name>.ts` with the handler function.
+2. Create the thin route file in `src/app/api/comic/[id]/<endpoint>/route.ts`.
+3. The route file: parse request → call handler → return `NextResponse.json(...)`.
+4. Error responses use `{ error: string }` with an appropriate HTTP status.
+5. For long-running routes (image generation), add `export const maxDuration = 300;` to the route file.
+
+---
+
+## Error Response Shape
+
+```typescript
+// All errors follow this shape
+return NextResponse.json({ error: "Human-readable message" }, { status: 400 });
+```
+
+Status codes: 200/201 success, 400 bad request / validation, 401 not authenticated, 403 not owner, 404 not found, 500 unexpected.
+
+---
+
+## PRD Reference
+
+Full API contracts, DB schema, AI prompts, and sequence diagrams are in:
+`references/comicly-technical-prd.md` — Sections 4 (Auth), 5 (Data Models), 6 (API Contract), 7 (AI Pipeline), 9 (Storage).
+
+---
+
+## Working Preferences
+
+### PRD Is the Source of Truth
+- Follow `references/comicly-technical-prd.md` exactly. Do not add endpoints, fields, or behaviour not described in it.
+- **⚠️ If you need to deviate from the PRD for any reason (technical limitation, ambiguity, better approach), STOP and flag it in bold before proceeding. Never silently deviate.**
+- **⚠️ If any requirement is unclear or missing detail, ASK before implementing. Do not guess.**
+
+### Issue Build Order
+
+Branch naming: `reghu/<feature-slug>` — one branch per issue, merge to `main` via PR.
+
+**Sprint 1 — Foundation and Core Loop**
+```
+#9  Project scaffolding and Supabase setup          ← start here    reghu/project-setup
+#10 CLAUDE.md and Claude Code tooling setup                          reghu/claude-md-setup
+#11 Gemini client and AI pipeline foundation        ← depends on #9  reghu/ai-pipeline
+#12 Database query layer and storage helpers        ← depends on #9  reghu/db-layer
+#13 Comic creation and random idea API routes       ← depends on #11, #12  reghu/comic-creation-api
+#14 Refine, script generation, and approve routes   ← depends on #13  reghu/script-api
+#15 Automated mode generation and comic retrieval   ← depends on #14  reghu/automated-generation
+```
+
+**Sprint 2 — Auth, Creative Control, and Library**
+```
+#20 Supabase Auth setup and middleware                               reghu/auth-setup
+#21 Script regeneration API                                          reghu/script-regeneration
+#22 Supervised mode API routes                                       reghu/supervised-mode
+#23 Library API and delete endpoint                 ← depends on #20  reghu/library-api
+#24 PDF export API route                            ← low priority   reghu/pdf-export
+```
+
+**Sprint 3 — Testing, Security, CI/CD**
+```
+#31 Backend unit and integration tests (TDD)                         reghu/backend-tests
+#32 Input validation with Zod                                        reghu/input-validation
+#33 CI/CD pipeline                                                   reghu/ci-pipeline
+#34 Security hardening                                               reghu/security-hardening
+```
+
+### Scope — Backend Only
+- Reghu owns backend only. Do not touch frontend code (`src/frontend/`, `src/app/(pages)/`).
+- Work is structured issue by issue (GitHub issues #9–#34 are Reghu's backend issues).
+
+### Issue-by-Issue Workflow
+1. Implement one GitHub issue completely.
+2. Stop and summarise what was built. Wait for Reghu's explicit confirmation.
+3. Only after confirmation: commit all changes for that issue.
+4. Only after committing: move to the next issue. Do not chain issues autonomously.
+
+### Commit After Each Approved Issue
+- Commit message must reference the issue number: `feat(backend): ... (#<issue-number>)`
+- Do not commit until Reghu explicitly approves the implementation.
+
+### Code Quality
+- All code must be TypeScript. No `.js` files.
+- Never use `any` unless absolutely necessary. When you must, add a comment explaining why.
+- Every API request body, response shape, and DB model must have an explicit interface or type. No untyped plain objects passed between functions.
+- Run `npm run lint` before considering any task done.
+
+### No Scope Creep
+- Do not implement anything not in the PRD — no extra endpoints, no unrequested fields, no "nice to haves".
+
+### Every Handler Must Be Complete
+- Every handler must cover all outcomes: success, validation failure, not found, auth error, and unexpected error. No half-finished error handling.

--- a/src/backend/handlers/approve-comic.ts
+++ b/src/backend/handlers/approve-comic.ts
@@ -1,0 +1,57 @@
+import type { Script, GenerationMode } from "@/backend/lib/types";
+import { getComic, saveComic } from "@/backend/lib/db";
+import { validateScript } from "@/backend/lib/ai/script-generator";
+
+interface ApproveComicInput {
+  script: Script;
+  generationMode: GenerationMode;
+}
+
+interface ApproveComicResult {
+  success: true;
+}
+
+const VALID_MODES: GenerationMode[] = ["supervised", "automated"];
+
+function validate(body: unknown): ApproveComicInput {
+  if (!body || typeof body !== "object") {
+    throw new Error("INVALID_INPUT: Request body is required");
+  }
+  const { script, generationMode } = body as Record<string, unknown>;
+
+  if (!script || typeof script !== "object") {
+    throw new Error("INVALID_INPUT: script is required");
+  }
+  if (!generationMode || !VALID_MODES.includes(generationMode as GenerationMode)) {
+    throw new Error("INVALID_INPUT: generationMode must be 'supervised' or 'automated'");
+  }
+
+  return {
+    script: script as Script,
+    generationMode: generationMode as GenerationMode,
+  };
+}
+
+export async function approveComic(
+  id: string,
+  body: unknown
+): Promise<ApproveComicResult> {
+  const input = validate(body);
+
+  const comic = await getComic(id);
+  if (!comic) throw new Error("NOT_FOUND: Comic not found");
+  if (comic.status !== "script_draft") {
+    throw new Error("STATUS_ERROR: Comic script is not in draft state");
+  }
+
+  validateScript(input.script, comic.pageCount);
+
+  await saveComic({
+    id,
+    script: input.script,
+    generationMode: input.generationMode,
+    status: "script_approved",
+  });
+
+  return { success: true };
+}

--- a/src/backend/handlers/create-comic.ts
+++ b/src/backend/handlers/create-comic.ts
@@ -1,0 +1,95 @@
+import type { ArtStylePreset, FollowUpQuestion } from "@/backend/lib/types";
+import { MIN_PAGES, MAX_PAGES } from "@/backend/lib/constants";
+import { getOptionalUser } from "@/backend/lib/supabase/middleware";
+import { generateFollowUpQuestions } from "@/backend/lib/ai/script-generator";
+import { saveComic } from "@/backend/lib/db";
+
+const VALID_ART_STYLES: ArtStylePreset[] = [
+  "manga",
+  "western_comic",
+  "watercolor_storybook",
+  "minimalist_flat",
+  "vintage_newspaper",
+  "custom",
+];
+
+interface CreateComicInput {
+  prompt: string;
+  artStyle: ArtStylePreset;
+  customStylePrompt?: string | null;
+  pageCount: number;
+}
+
+interface CreateComicResult {
+  comicId: string;
+  followUpQuestions: FollowUpQuestion[];
+}
+
+function validate(body: unknown): CreateComicInput {
+  if (!body || typeof body !== "object") {
+    throw new Error("INVALID_INPUT: Request body is required");
+  }
+
+  const { prompt, artStyle, customStylePrompt, pageCount } = body as Record<string, unknown>;
+
+  if (!prompt || typeof prompt !== "string" || prompt.trim() === "") {
+    throw new Error("INVALID_INPUT: prompt is required and must be a non-empty string");
+  }
+
+  if (!artStyle || !VALID_ART_STYLES.includes(artStyle as ArtStylePreset)) {
+    throw new Error(
+      `INVALID_INPUT: artStyle must be one of: ${VALID_ART_STYLES.join(", ")}`
+    );
+  }
+
+  if (artStyle === "custom" && (!customStylePrompt || typeof customStylePrompt !== "string" || customStylePrompt.trim() === "")) {
+    throw new Error("INVALID_INPUT: customStylePrompt is required when artStyle is 'custom'");
+  }
+
+  if (
+    typeof pageCount !== "number" ||
+    !Number.isInteger(pageCount) ||
+    pageCount < MIN_PAGES ||
+    pageCount > MAX_PAGES
+  ) {
+    throw new Error(
+      `INVALID_INPUT: pageCount must be an integer between ${MIN_PAGES} and ${MAX_PAGES}`
+    );
+  }
+
+  return {
+    prompt: prompt.trim(),
+    artStyle: artStyle as ArtStylePreset,
+    customStylePrompt: typeof customStylePrompt === "string" ? customStylePrompt : undefined,
+    pageCount,
+  };
+}
+
+export async function createComic(body: unknown): Promise<CreateComicResult> {
+  const input = validate(body);
+
+  const user = await getOptionalUser();
+
+  const followUpQuestions = await generateFollowUpQuestions(
+    input.prompt,
+    input.artStyle,
+    input.pageCount
+  );
+
+  const comicId = crypto.randomUUID();
+
+  await saveComic({
+    id: comicId,
+    userId: user?.id ?? null,
+    status: "input",
+    prompt: input.prompt,
+    artStyle: input.artStyle,
+    customStylePrompt: input.customStylePrompt ?? undefined,
+    pageCount: input.pageCount,
+    followUpQuestions,
+    currentPageIndex: 0,
+    pages: [],
+  });
+
+  return { comicId, followUpQuestions };
+}

--- a/src/backend/handlers/create-comic.ts
+++ b/src/backend/handlers/create-comic.ts
@@ -2,7 +2,7 @@ import type { ArtStylePreset, FollowUpQuestion } from "@/backend/lib/types";
 import { MIN_PAGES, MAX_PAGES } from "@/backend/lib/constants";
 import { getOptionalUser } from "@/backend/lib/supabase/middleware";
 import { generateFollowUpQuestions } from "@/backend/lib/ai/script-generator";
-import { saveComic } from "@/backend/lib/db";
+import { insertComic } from "@/backend/lib/db";
 
 const VALID_ART_STYLES: ArtStylePreset[] = [
   "manga",
@@ -78,7 +78,7 @@ export async function createComic(body: unknown): Promise<CreateComicResult> {
 
   const comicId = crypto.randomUUID();
 
-  await saveComic({
+  await insertComic({
     id: comicId,
     userId: user?.id ?? null,
     status: "input",

--- a/src/backend/handlers/generate-script.ts
+++ b/src/backend/handlers/generate-script.ts
@@ -1,0 +1,26 @@
+import type { Script } from "@/backend/lib/types";
+import { getComic, saveComic } from "@/backend/lib/db";
+import { generateScript } from "@/backend/lib/ai/script-generator";
+
+interface GenerateScriptResult {
+  script: Script;
+}
+
+export async function generateComicScript(id: string): Promise<GenerateScriptResult> {
+  const comic = await getComic(id);
+  if (!comic) throw new Error("NOT_FOUND: Comic not found");
+  if (comic.status !== "script_pending") {
+    throw new Error("STATUS_ERROR: Comic is not ready for script generation");
+  }
+
+  const script = await generateScript(
+    comic.prompt,
+    comic.artStyle,
+    comic.pageCount,
+    comic.followUpAnswers
+  );
+
+  await saveComic({ id, script, status: "script_draft" });
+
+  return { script };
+}

--- a/src/backend/handlers/get-comic.ts
+++ b/src/backend/handlers/get-comic.ts
@@ -1,0 +1,12 @@
+import type { Comic } from "@/backend/lib/types";
+import { getComic as getComicFromDb } from "@/backend/lib/db";
+
+interface GetComicResult {
+  comic: Comic;
+}
+
+export async function getComic(id: string): Promise<GetComicResult> {
+  const comic = await getComicFromDb(id);
+  if (!comic) throw new Error("NOT_FOUND: Comic not found");
+  return { comic };
+}

--- a/src/backend/handlers/random-idea.ts
+++ b/src/backend/handlers/random-idea.ts
@@ -1,0 +1,10 @@
+import { generateRandomIdea } from "@/backend/lib/ai/script-generator";
+
+interface RandomIdeaResult {
+  idea: string;
+}
+
+export async function randomIdea(): Promise<RandomIdeaResult> {
+  const idea = await generateRandomIdea();
+  return { idea: idea.trim() };
+}

--- a/src/backend/handlers/refine-comic.ts
+++ b/src/backend/handlers/refine-comic.ts
@@ -1,0 +1,46 @@
+import { getComic, saveComic } from "@/backend/lib/db";
+
+interface RefineComicInput {
+  answers: Record<string, string>;
+}
+
+interface RefineComicResult {
+  success: true;
+}
+
+function validate(body: unknown): RefineComicInput {
+  if (!body || typeof body !== "object") {
+    throw new Error("INVALID_INPUT: Request body is required");
+  }
+  const { answers } = body as Record<string, unknown>;
+  if (!answers || typeof answers !== "object" || Array.isArray(answers)) {
+    throw new Error("INVALID_INPUT: answers must be an object");
+  }
+  for (const [key, val] of Object.entries(answers)) {
+    if (typeof val !== "string") {
+      throw new Error(`INVALID_INPUT: answer for ${key} must be a string`);
+    }
+  }
+  return { answers: answers as Record<string, string> };
+}
+
+export async function refineComic(
+  id: string,
+  body: unknown
+): Promise<RefineComicResult> {
+  const input = validate(body);
+
+  const comic = await getComic(id);
+  if (!comic) throw new Error("NOT_FOUND: Comic not found");
+  if (comic.status !== "input") {
+    throw new Error("STATUS_ERROR: Comic is not awaiting follow-up answers");
+  }
+
+  await saveComic({
+    id,
+    followUpAnswers: input.answers,
+    status: "script_pending",
+  });
+
+  return { success: true };
+}

--- a/src/backend/lib/__tests__/db.test.ts
+++ b/src/backend/lib/__tests__/db.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("@/backend/lib/supabase/server", () => ({
+  supabaseAdmin: {},
+}));
+
+import {
+  mapDbToPageVersion,
+  mapDbToPage,
+  mapDbToComic,
+  mapDbToSummary,
+  mapComicToDb,
+} from "../db";
+
+const dbVersion = {
+  id: "v1",
+  page_id: "p1",
+  version_index: 0,
+  image_url: "https://example.com/image.png",
+  generated_at: "2026-04-01T00:00:00Z",
+};
+
+const dbPage = {
+  id: "p1",
+  comic_id: "c1",
+  page_number: 1,
+  selected_version_index: 0,
+  created_at: "2026-04-01T00:00:00Z",
+  page_versions: [dbVersion],
+};
+
+const dbComic = {
+  id: "c1",
+  user_id: "u1",
+  status: "script_draft" as const,
+  created_at: "2026-04-01T00:00:00Z",
+  updated_at: "2026-04-01T01:00:00Z",
+  prompt: "A ninja cat",
+  art_style: "manga" as const,
+  custom_style_prompt: null,
+  page_count: 3,
+  follow_up_questions: [{ id: "q1", question: "Name?" }],
+  follow_up_answers: { q1: "Whiskers" },
+  script: { title: "Ninja Cat", synopsis: "A short tale.", pages: [] },
+  generation_mode: null,
+  current_page_index: 0,
+};
+
+describe("mapDbToPageVersion", () => {
+  it("maps image_url to imageUrl", () => {
+    expect(mapDbToPageVersion(dbVersion).imageUrl).toBe(
+      "https://example.com/image.png"
+    );
+  });
+
+  it("maps generated_at to generatedAt", () => {
+    expect(mapDbToPageVersion(dbVersion).generatedAt).toBe(
+      "2026-04-01T00:00:00Z"
+    );
+  });
+});
+
+describe("mapDbToPage", () => {
+  it("maps page_number to pageNumber", () => {
+    expect(mapDbToPage(dbPage).pageNumber).toBe(1);
+  });
+
+  it("maps selected_version_index to selectedVersionIndex", () => {
+    expect(mapDbToPage(dbPage).selectedVersionIndex).toBe(0);
+  });
+
+  it("maps page_versions to versions array", () => {
+    expect(mapDbToPage(dbPage).versions).toHaveLength(1);
+    expect(mapDbToPage(dbPage).versions[0].imageUrl).toBe(
+      "https://example.com/image.png"
+    );
+  });
+
+  it("sorts versions by version_index", () => {
+    const pageWithMultiple = {
+      ...dbPage,
+      page_versions: [
+        { ...dbVersion, version_index: 2, image_url: "img2.png" },
+        { ...dbVersion, version_index: 0, image_url: "img0.png" },
+        { ...dbVersion, version_index: 1, image_url: "img1.png" },
+      ],
+    };
+    const result = mapDbToPage(pageWithMultiple);
+    expect(result.versions[0].imageUrl).toBe("img0.png");
+    expect(result.versions[1].imageUrl).toBe("img1.png");
+    expect(result.versions[2].imageUrl).toBe("img2.png");
+  });
+
+  it("handles missing page_versions gracefully", () => {
+    const pageWithoutVersions = { ...dbPage, page_versions: undefined };
+    expect(mapDbToPage(pageWithoutVersions).versions).toHaveLength(0);
+  });
+});
+
+describe("mapDbToComic", () => {
+  it("maps all snake_case fields to camelCase", () => {
+    const result = mapDbToComic(dbComic, [dbPage]);
+    expect(result.id).toBe("c1");
+    expect(result.userId).toBe("u1");
+    expect(result.artStyle).toBe("manga");
+    expect(result.pageCount).toBe(3);
+    expect(result.createdAt).toBe("2026-04-01T00:00:00Z");
+    expect(result.updatedAt).toBe("2026-04-01T01:00:00Z");
+    expect(result.currentPageIndex).toBe(0);
+  });
+
+  it("maps null custom_style_prompt to undefined", () => {
+    const result = mapDbToComic(dbComic, null);
+    expect(result.customStylePrompt).toBeUndefined();
+  });
+
+  it("maps null generation_mode to undefined", () => {
+    const result = mapDbToComic(dbComic, null);
+    expect(result.generationMode).toBeUndefined();
+  });
+
+  it("maps follow_up_questions correctly", () => {
+    const result = mapDbToComic(dbComic, null);
+    expect(result.followUpQuestions).toEqual([{ id: "q1", question: "Name?" }]);
+  });
+
+  it("maps script correctly", () => {
+    const result = mapDbToComic(dbComic, null);
+    expect(result.script?.title).toBe("Ninja Cat");
+  });
+
+  it("maps pages array", () => {
+    const result = mapDbToComic(dbComic, [dbPage]);
+    expect(result.pages).toHaveLength(1);
+    expect(result.pages[0].pageNumber).toBe(1);
+  });
+
+  it("returns empty pages when pages is null", () => {
+    const result = mapDbToComic(dbComic, null);
+    expect(result.pages).toHaveLength(0);
+  });
+});
+
+describe("mapDbToSummary", () => {
+  it("uses script title", () => {
+    const result = mapDbToSummary(dbComic, dbPage);
+    expect(result.title).toBe("Ninja Cat");
+  });
+
+  it("returns null title when no script", () => {
+    const comicWithoutScript = { ...dbComic, script: null };
+    const result = mapDbToSummary(comicWithoutScript, undefined);
+    expect(result.title).toBeNull();
+  });
+
+  it("returns thumbnail from selected version", () => {
+    const result = mapDbToSummary(dbComic, dbPage);
+    expect(result.thumbnailUrl).toBe("https://example.com/image.png");
+  });
+
+  it("returns null thumbnail when no first page", () => {
+    const result = mapDbToSummary(dbComic, undefined);
+    expect(result.thumbnailUrl).toBeNull();
+  });
+
+  it("returns null thumbnail when selected version not found", () => {
+    const pageWithWrongIndex = {
+      ...dbPage,
+      selected_version_index: 5,
+    };
+    const result = mapDbToSummary(dbComic, pageWithWrongIndex);
+    expect(result.thumbnailUrl).toBeNull();
+  });
+
+  it("maps all base fields correctly", () => {
+    const result = mapDbToSummary(dbComic, undefined);
+    expect(result.id).toBe("c1");
+    expect(result.status).toBe("script_draft");
+    expect(result.artStyle).toBe("manga");
+    expect(result.pageCount).toBe(3);
+  });
+});
+
+describe("mapComicToDb", () => {
+  it("always includes id", () => {
+    const result = mapComicToDb({ id: "c1" });
+    expect(result.id).toBe("c1");
+  });
+
+  it("maps camelCase fields to snake_case", () => {
+    const result = mapComicToDb({
+      id: "c1",
+      artStyle: "western_comic",
+      pageCount: 5,
+      currentPageIndex: 2,
+    });
+    expect(result.art_style).toBe("western_comic");
+    expect(result.page_count).toBe(5);
+    expect(result.current_page_index).toBe(2);
+  });
+
+  it("omits fields that are not provided", () => {
+    const result = mapComicToDb({ id: "c1", status: "generating" });
+    expect(result.status).toBe("generating");
+    expect(result.art_style).toBeUndefined();
+    expect(result.page_count).toBeUndefined();
+  });
+
+  it("maps userId to user_id", () => {
+    const result = mapComicToDb({ id: "c1", userId: "u1" });
+    expect(result.user_id).toBe("u1");
+  });
+
+  it("maps generationMode to generation_mode", () => {
+    const result = mapComicToDb({ id: "c1", generationMode: "automated" });
+    expect(result.generation_mode).toBe("automated");
+  });
+});

--- a/src/backend/lib/ai/__tests__/prompts.test.ts
+++ b/src/backend/lib/ai/__tests__/prompts.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildFollowUpQuestionsPrompt,
+  buildRandomIdeaPrompt,
+  buildScriptPrompt,
+  buildScriptRegenerationPrompt,
+  buildImagePrompt,
+  buildJsonRetryPrompt,
+} from "../prompts";
+import type { Script, ScriptPage } from "@/backend/lib/types";
+
+const mockScript: Script = {
+  title: "Test Comic",
+  synopsis: "A test synopsis.",
+  pages: [
+    {
+      pageNumber: 1,
+      panels: [
+        {
+          panelNumber: 1,
+          description: "A hero stands on a rooftop.",
+          dialogue: [{ speaker: "Hero", text: "Let's go!" }],
+        },
+      ],
+    },
+  ],
+};
+
+const mockPage: ScriptPage = {
+  pageNumber: 1,
+  panels: [
+    {
+      panelNumber: 1,
+      description: "A detective examines a clue.",
+      dialogue: [{ speaker: "Detective", text: "Interesting..." }],
+      caption: "The mystery deepens.",
+    },
+    {
+      panelNumber: 2,
+      description: "A wide shot of the city at night.",
+      dialogue: [],
+    },
+  ],
+};
+
+describe("buildFollowUpQuestionsPrompt", () => {
+  it("includes the user prompt", () => {
+    const result = buildFollowUpQuestionsPrompt("A space adventure", "manga", 5);
+    expect(result).toContain("A space adventure");
+  });
+
+  it("includes art style", () => {
+    const result = buildFollowUpQuestionsPrompt("A space adventure", "manga", 5);
+    expect(result).toContain("manga");
+  });
+
+  it("includes page count", () => {
+    const result = buildFollowUpQuestionsPrompt("A space adventure", "manga", 5);
+    expect(result).toContain("5");
+  });
+
+  it("instructs to return JSON array with id and question fields", () => {
+    const result = buildFollowUpQuestionsPrompt("A space adventure", "manga", 5);
+    expect(result).toContain('"id"');
+    expect(result).toContain('"question"');
+  });
+});
+
+describe("buildRandomIdeaPrompt", () => {
+  it("returns a non-empty string", () => {
+    const result = buildRandomIdeaPrompt();
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it("instructs to return only the premise text", () => {
+    const result = buildRandomIdeaPrompt();
+    expect(result).toContain("ONLY");
+  });
+});
+
+describe("buildScriptPrompt", () => {
+  it("includes the prompt", () => {
+    const result = buildScriptPrompt("Ninja cats", "western_comic", 3);
+    expect(result).toContain("Ninja cats");
+  });
+
+  it("includes art style", () => {
+    const result = buildScriptPrompt("Ninja cats", "western_comic", 3);
+    expect(result).toContain("western_comic");
+  });
+
+  it("includes page count", () => {
+    const result = buildScriptPrompt("Ninja cats", "western_comic", 3);
+    expect(result).toContain("3");
+  });
+
+  it("includes follow-up answers when provided", () => {
+    const result = buildScriptPrompt("Ninja cats", "western_comic", 3, {
+      q1: "Very sneaky",
+    });
+    expect(result).toContain("Very sneaky");
+  });
+
+  it("handles missing follow-up answers gracefully", () => {
+    const result = buildScriptPrompt("Ninja cats", "western_comic", 3, undefined);
+    expect(result).toContain("No additional details provided");
+  });
+
+  it("instructs to return only valid JSON", () => {
+    const result = buildScriptPrompt("Ninja cats", "western_comic", 3);
+    expect(result).toContain("ONLY valid JSON");
+  });
+});
+
+describe("buildScriptRegenerationPrompt", () => {
+  it("includes the current script JSON", () => {
+    const result = buildScriptRegenerationPrompt(
+      "Ninja cats", "western_comic", 1, undefined, mockScript, "Make it funnier"
+    );
+    expect(result).toContain("Test Comic");
+  });
+
+  it("includes the user feedback", () => {
+    const result = buildScriptRegenerationPrompt(
+      "Ninja cats", "western_comic", 1, undefined, mockScript, "Make it funnier"
+    );
+    expect(result).toContain("Make it funnier");
+  });
+
+  it("still enforces page count rules", () => {
+    const result = buildScriptRegenerationPrompt(
+      "Ninja cats", "western_comic", 1, undefined, mockScript, "Make it funnier"
+    );
+    expect(result).toContain("ONLY valid JSON");
+  });
+});
+
+describe("buildImagePrompt", () => {
+  it("includes the comic title", () => {
+    const result = buildImagePrompt(mockPage, "manga", "Detective Nights", 5);
+    expect(result).toContain("Detective Nights");
+  });
+
+  it("includes the page number and total pages", () => {
+    const result = buildImagePrompt(mockPage, "manga", "Detective Nights", 5);
+    expect(result).toContain("page 1 of 5");
+  });
+
+  it("includes panel descriptions", () => {
+    const result = buildImagePrompt(mockPage, "manga", "Detective Nights", 5);
+    expect(result).toContain("A detective examines a clue.");
+  });
+
+  it("includes dialogue", () => {
+    const result = buildImagePrompt(mockPage, "manga", "Detective Nights", 5);
+    expect(result).toContain("Interesting...");
+  });
+
+  it("includes caption when present", () => {
+    const result = buildImagePrompt(mockPage, "manga", "Detective Nights", 5);
+    expect(result).toContain("The mystery deepens.");
+  });
+
+  it("uses art style prompt fragment for presets", () => {
+    const result = buildImagePrompt(mockPage, "manga", "Detective Nights", 5);
+    expect(result).toContain("manga");
+  });
+
+  it("uses custom style prompt verbatim for custom art style", () => {
+    const result = buildImagePrompt(mockPage, "custom", "Detective Nights", 5, "oil painting style");
+    expect(result).toContain("oil painting style");
+  });
+
+  it("includes aspect ratio", () => {
+    const result = buildImagePrompt(mockPage, "manga", "Detective Nights", 5);
+    expect(result).toContain("2:3");
+  });
+});
+
+describe("buildJsonRetryPrompt", () => {
+  it("mentions invalid JSON", () => {
+    const result = buildJsonRetryPrompt();
+    expect(result).toContain("not valid JSON");
+  });
+});

--- a/src/backend/lib/ai/gemini-client.ts
+++ b/src/backend/lib/ai/gemini-client.ts
@@ -1,0 +1,3 @@
+import { GoogleGenAI } from "@google/genai";
+
+export const ai = new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY });

--- a/src/backend/lib/ai/image-generator.ts
+++ b/src/backend/lib/ai/image-generator.ts
@@ -1,0 +1,37 @@
+import type { ArtStylePreset, ScriptPage } from "@/backend/lib/types";
+import { IMAGE_ASPECT_RATIO, IMAGE_RESOLUTION } from "@/backend/lib/constants";
+import { ai } from "./gemini-client";
+import { buildImagePrompt } from "./prompts";
+
+const IMAGE_MODEL = "gemini-3-pro-image-preview";
+
+export async function generatePageImage(
+  page: ScriptPage,
+  artStyle: ArtStylePreset,
+  title: string,
+  totalPages: number,
+  customStylePrompt?: string
+): Promise<Buffer> {
+  const prompt = buildImagePrompt(page, artStyle, title, totalPages, customStylePrompt);
+
+  const response = await ai.models.generateContent({
+    model: IMAGE_MODEL,
+    contents: prompt,
+    config: {
+      responseModalities: ["IMAGE"],
+      imageConfig: {
+        aspectRatio: IMAGE_ASPECT_RATIO,
+        imageSize: IMAGE_RESOLUTION,
+      },
+    },
+  });
+
+  const parts = response.candidates?.[0]?.content?.parts ?? [];
+  for (const part of parts) {
+    if (part.inlineData?.data) {
+      return Buffer.from(part.inlineData.data, "base64");
+    }
+  }
+
+  throw new Error("No image returned from Nano Banana Pro");
+}

--- a/src/backend/lib/ai/prompts.ts
+++ b/src/backend/lib/ai/prompts.ts
@@ -1,0 +1,153 @@
+import type { ArtStylePreset, Script, ScriptPage } from "@/backend/lib/types";
+import { ART_STYLE_PRESETS, IMAGE_ASPECT_RATIO } from "@/backend/lib/constants";
+
+function getArtStyleDescription(artStyle: ArtStylePreset, customStylePrompt?: string): string {
+  if (artStyle === "custom") {
+    return customStylePrompt ?? "custom style";
+  }
+  return ART_STYLE_PRESETS[artStyle].promptFragment;
+}
+
+export function buildFollowUpQuestionsPrompt(
+  prompt: string,
+  artStyle: ArtStylePreset,
+  pageCount: number
+): string {
+  return `You are a creative comic book editor. Given a user's comic idea, generate up to 5 short follow-up questions that would help personalize the story. Focus on character details, setting specifics, tone, and plot preferences. Do NOT ask about art style or length — those are already decided.
+
+Respond with ONLY a JSON array of objects with "id" and "question" fields. No other text.
+
+Example:
+[
+  {"id": "q1", "question": "What's the main character's personality like?"},
+  {"id": "q2", "question": "Should the ending be happy, bittersweet, or a cliffhanger?"}
+]
+
+User's idea: "${prompt}"
+Art style: "${artStyle}"
+Number of pages: ${pageCount}`;
+}
+
+export function buildRandomIdeaPrompt(): string {
+  return `Generate a single creative, fun, and specific comic book premise in one to two sentences. Be imaginative and varied — mix genres, settings, and characters. Do not repeat common tropes. Return ONLY the premise text, nothing else.`;
+}
+
+function formatFollowUpAnswers(answers?: Record<string, string>): string {
+  if (!answers || Object.keys(answers).length === 0) {
+    return "No additional details provided.";
+  }
+  return Object.entries(answers)
+    .map(([id, answer]) => `${id}: ${answer}`)
+    .join("\n");
+}
+
+const SCRIPT_SYSTEM_PROMPT = `You are a professional comic book writer. Write a complete comic script based on the user's input.
+
+Rules:
+- The script MUST have exactly {pageCount} pages.
+- Each page MUST have between 2 and 6 panels.
+- Each panel MUST include a "description" field with a detailed visual description suitable for an AI image generator. Include character appearances, poses, expressions, camera angles, lighting, and background details.
+- Dialogue should be natural and fit the genre.
+- Captions are optional narrator text.
+- The story must have a clear beginning, middle, and end.
+- Respond with ONLY valid JSON matching this exact structure, no other text:
+
+{
+  "title": "string",
+  "synopsis": "string (2-3 sentences)",
+  "pages": [
+    {
+      "pageNumber": 1,
+      "panels": [
+        {
+          "panelNumber": 1,
+          "description": "Detailed visual description...",
+          "dialogue": [{"speaker": "Name", "text": "What they say"}],
+          "caption": "Optional narrator text or null"
+        }
+      ]
+    }
+  ]
+}`;
+
+export function buildScriptPrompt(
+  prompt: string,
+  artStyle: ArtStylePreset,
+  pageCount: number,
+  followUpAnswers?: Record<string, string>
+): string {
+  return `${SCRIPT_SYSTEM_PROMPT.replace("{pageCount}", String(pageCount))}
+
+User's idea: "${prompt}"
+Art style: "${artStyle}"
+Number of pages: ${pageCount}
+Additional details from the user:
+${formatFollowUpAnswers(followUpAnswers)}`;
+}
+
+export function buildScriptRegenerationPrompt(
+  prompt: string,
+  artStyle: ArtStylePreset,
+  pageCount: number,
+  followUpAnswers: Record<string, string> | undefined,
+  currentScript: Script,
+  feedback: string
+): string {
+  return `${SCRIPT_SYSTEM_PROMPT.replace("{pageCount}", String(pageCount))}
+
+User's idea: "${prompt}"
+Art style: "${artStyle}"
+Number of pages: ${pageCount}
+Additional details from the user:
+${formatFollowUpAnswers(followUpAnswers)}
+
+Here is the current script that the user wants revised:
+${JSON.stringify(currentScript, null, 2)}
+
+The user's feedback on what to change:
+"${feedback}"
+
+Rewrite the script incorporating this feedback while keeping the same structure requirements.`;
+}
+
+export function buildImagePrompt(
+  page: ScriptPage,
+  artStyle: ArtStylePreset,
+  title: string,
+  totalPages: number,
+  customStylePrompt?: string
+): string {
+  const artStyleDescription = getArtStyleDescription(artStyle, customStylePrompt);
+
+  const panelDescriptions = page.panels
+    .map((panel) => {
+      const dialogueLines = panel.dialogue
+        .map((d) => `${d.speaker}: "${d.text}"`)
+        .join("\n  ");
+      const captionLine = panel.caption ? `\n  Caption: ${panel.caption}` : "";
+      return `Panel ${panel.panelNumber}:
+  Scene: ${panel.description}
+  Dialogue:\n  ${dialogueLines || "(none)"}${captionLine}`;
+    })
+    .join("\n\n");
+
+  return `Create a single comic book page illustration in ${artStyleDescription} style.
+
+This is page ${page.pageNumber} of ${totalPages} in a comic called "${title}".
+
+The page has ${page.panels.length} panels arranged in a comic book layout:
+
+${panelDescriptions}
+
+Important instructions:
+- Render this as a SINGLE comic book page with clearly defined panel borders.
+- Include speech bubbles with the dialogue text inside each panel.
+- Include caption boxes for narrator text where specified.
+- Maintain consistent character appearances across all panels.
+- The overall style must be: ${artStyleDescription}
+- Use a ${IMAGE_ASPECT_RATIO} aspect ratio.`;
+}
+
+export function buildJsonRetryPrompt(): string {
+  return "Your previous response was not valid JSON. Please try again with ONLY valid JSON, no markdown fences or extra text.";
+}

--- a/src/backend/lib/ai/script-generator.ts
+++ b/src/backend/lib/ai/script-generator.ts
@@ -20,15 +20,19 @@ async function callGeminiText(prompt: string): Promise<string> {
   return response.text ?? "";
 }
 
+function stripCodeFences(text: string): string {
+  return text.replace(/^```(?:json)?\s*/m, "").replace(/\s*```\s*$/m, "").trim();
+}
+
 async function parseJsonWithRetry<T>(
   firstResponse: string,
   retryPrompt: () => Promise<string>
 ): Promise<T> {
   try {
-    return JSON.parse(firstResponse) as T;
+    return JSON.parse(stripCodeFences(firstResponse)) as T;
   } catch {
     const retried = await retryPrompt();
-    return JSON.parse(retried) as T;
+    return JSON.parse(stripCodeFences(retried)) as T;
   }
 }
 

--- a/src/backend/lib/ai/script-generator.ts
+++ b/src/backend/lib/ai/script-generator.ts
@@ -1,0 +1,122 @@
+import type { ArtStylePreset, Script } from "@/backend/lib/types";
+import { MIN_PANELS_PER_PAGE, MAX_PANELS_PER_PAGE } from "@/backend/lib/constants";
+import { ai } from "./gemini-client";
+import {
+  buildFollowUpQuestionsPrompt,
+  buildRandomIdeaPrompt,
+  buildScriptPrompt,
+  buildScriptRegenerationPrompt,
+  buildJsonRetryPrompt,
+} from "./prompts";
+import type { FollowUpQuestion } from "@/backend/lib/types";
+
+const TEXT_MODEL = "gemini-2.5-flash";
+
+async function callGeminiText(prompt: string): Promise<string> {
+  const response = await ai.models.generateContent({
+    model: TEXT_MODEL,
+    contents: prompt,
+  });
+  return response.text ?? "";
+}
+
+async function parseJsonWithRetry<T>(
+  firstResponse: string,
+  retryPrompt: () => Promise<string>
+): Promise<T> {
+  try {
+    return JSON.parse(firstResponse) as T;
+  } catch {
+    const retried = await retryPrompt();
+    return JSON.parse(retried) as T;
+  }
+}
+
+function validateScript(script: Script, expectedPageCount: number): void {
+  if (!script.title || typeof script.title !== "string") {
+    throw new Error("Script missing title");
+  }
+  if (!Array.isArray(script.pages) || script.pages.length !== expectedPageCount) {
+    throw new Error(
+      `Script has ${script.pages?.length ?? 0} pages, expected ${expectedPageCount}`
+    );
+  }
+  for (const page of script.pages) {
+    const panelCount = page.panels?.length ?? 0;
+    if (panelCount < MIN_PANELS_PER_PAGE || panelCount > MAX_PANELS_PER_PAGE) {
+      throw new Error(
+        `Page ${page.pageNumber} has ${panelCount} panels (must be ${MIN_PANELS_PER_PAGE}–${MAX_PANELS_PER_PAGE})`
+      );
+    }
+  }
+}
+
+export async function generateFollowUpQuestions(
+  prompt: string,
+  artStyle: ArtStylePreset,
+  pageCount: number
+): Promise<FollowUpQuestion[]> {
+  const aiPrompt = buildFollowUpQuestionsPrompt(prompt, artStyle, pageCount);
+  const raw = await callGeminiText(aiPrompt);
+
+  const questions = await parseJsonWithRetry<FollowUpQuestion[]>(raw, async () => {
+    const retryRaw = await callGeminiText(buildJsonRetryPrompt());
+    return retryRaw;
+  });
+
+  if (!Array.isArray(questions)) {
+    throw new Error("Follow-up questions response is not an array");
+  }
+
+  return questions;
+}
+
+export async function generateRandomIdea(): Promise<string> {
+  const prompt = buildRandomIdeaPrompt();
+  return callGeminiText(prompt);
+}
+
+export async function generateScript(
+  prompt: string,
+  artStyle: ArtStylePreset,
+  pageCount: number,
+  followUpAnswers?: Record<string, string>
+): Promise<Script> {
+  const aiPrompt = buildScriptPrompt(prompt, artStyle, pageCount, followUpAnswers);
+  const raw = await callGeminiText(aiPrompt);
+
+  const script = await parseJsonWithRetry<Script>(raw, async () => {
+    const retryRaw = await callGeminiText(buildJsonRetryPrompt());
+    return retryRaw;
+  });
+
+  validateScript(script, pageCount);
+  return script;
+}
+
+export async function regenerateScript(
+  prompt: string,
+  artStyle: ArtStylePreset,
+  pageCount: number,
+  followUpAnswers: Record<string, string> | undefined,
+  currentScript: Script,
+  feedback: string
+): Promise<Script> {
+  const aiPrompt = buildScriptRegenerationPrompt(
+    prompt,
+    artStyle,
+    pageCount,
+    followUpAnswers,
+    currentScript,
+    feedback
+  );
+  const raw = await callGeminiText(aiPrompt);
+
+  const script = await parseJsonWithRetry<Script>(raw, async () => {
+    const retryRaw = await callGeminiText(buildJsonRetryPrompt());
+    return retryRaw;
+  });
+
+  validateScript(script, pageCount);
+  return script;
+}

--- a/src/backend/lib/ai/script-generator.ts
+++ b/src/backend/lib/ai/script-generator.ts
@@ -36,7 +36,7 @@ async function parseJsonWithRetry<T>(
   }
 }
 
-function validateScript(script: Script, expectedPageCount: number): void {
+export function validateScript(script: Script, expectedPageCount: number): void {
   if (!script.title || typeof script.title !== "string") {
     throw new Error("Script missing title");
   }

--- a/src/backend/lib/constants.ts
+++ b/src/backend/lib/constants.ts
@@ -1,0 +1,37 @@
+export const MAX_PAGES = 15;
+export const MIN_PAGES = 1;
+export const MAX_PANELS_PER_PAGE = 6;
+export const MIN_PANELS_PER_PAGE = 2;
+export const MAX_PAGE_REGENERATIONS = 3;  // 3 regens = 4 total versions
+export const MAX_FOLLOW_UP_QUESTIONS = 5;
+
+export const ART_STYLE_PRESETS = {
+  manga: {
+    label: "Manga",
+    description: "Japanese manga style with expressive characters and dynamic compositions",
+    promptFragment: "Japanese manga style with screentones, dynamic action lines, expressive eyes, and black-and-white ink aesthetic",
+  },
+  western_comic: {
+    label: "Western Comic",
+    description: "Bold American comic book style with vivid colors",
+    promptFragment: "American superhero comic style with bold outlines, vivid colors, dynamic poses, and halftone dot shading",
+  },
+  watercolor_storybook: {
+    label: "Watercolor Storybook",
+    description: "Soft, dreamy watercolor illustrations",
+    promptFragment: "Soft watercolor children's storybook style with gentle colors, flowing brushstrokes, and warm dreamy lighting",
+  },
+  minimalist_flat: {
+    label: "Minimalist / Flat",
+    description: "Clean, simple flat illustrations with limited colors",
+    promptFragment: "Minimalist flat illustration style with simple shapes, limited color palette, clean lines, and no gradients",
+  },
+  vintage_newspaper: {
+    label: "Vintage Newspaper",
+    description: "Retro newspaper comic strip aesthetic",
+    promptFragment: "Vintage newspaper comic strip style with muted colors, Ben-Day dots, retro lettering, and a yellowed paper texture",
+  },
+} as const;
+
+export const IMAGE_ASPECT_RATIO = "2:3";  // Portrait for comic pages
+export const IMAGE_RESOLUTION = "1K";      // Balance of quality and speed

--- a/src/backend/lib/db.ts
+++ b/src/backend/lib/db.ts
@@ -165,12 +165,24 @@ export async function getComic(id: string): Promise<Comic | null> {
   return mapDbToComic(comic as DbComic, pages as DbComicPage[] | null);
 }
 
-export async function saveComic(
+export async function insertComic(
   comic: Partial<Comic> & { id: string }
 ): Promise<void> {
   const { error } = await supabaseAdmin
     .from("comics")
-    .upsert(mapComicToDb(comic));
+    .insert(mapComicToDb(comic));
+
+  if (error) throw error;
+}
+
+export async function saveComic(
+  comic: Partial<Comic> & { id: string }
+): Promise<void> {
+  const { id, ...rest } = mapComicToDb(comic);
+  const { error } = await supabaseAdmin
+    .from("comics")
+    .update(rest)
+    .eq("id", id);
 
   if (error) throw error;
 }

--- a/src/backend/lib/db.ts
+++ b/src/backend/lib/db.ts
@@ -1,0 +1,262 @@
+import { supabaseAdmin } from "./supabase/server";
+import type {
+  Comic,
+  ComicSummary,
+  ComicStatus,
+  ArtStylePreset,
+  GenerationMode,
+  FollowUpQuestion,
+  Script,
+  Page,
+  PageVersion,
+} from "./types";
+
+// ---------------------------------------------------------------------------
+// Raw DB row types (snake_case)
+// ---------------------------------------------------------------------------
+
+interface DbComic {
+  id: string;
+  user_id: string | null;
+  status: ComicStatus;
+  created_at: string;
+  updated_at: string;
+  prompt: string;
+  art_style: ArtStylePreset;
+  custom_style_prompt: string | null;
+  page_count: number;
+  follow_up_questions: FollowUpQuestion[] | null;
+  follow_up_answers: Record<string, string> | null;
+  script: Script | null;
+  generation_mode: GenerationMode | null;
+  current_page_index: number;
+}
+
+interface DbPageVersion {
+  id: string;
+  page_id: string;
+  version_index: number;
+  image_url: string;
+  generated_at: string;
+}
+
+interface DbComicPage {
+  id: string;
+  comic_id: string;
+  page_number: number;
+  selected_version_index: number;
+  created_at: string;
+  page_versions?: DbPageVersion[];
+}
+
+// ---------------------------------------------------------------------------
+// Mapping functions (exported for unit testing)
+// ---------------------------------------------------------------------------
+
+export function mapDbToPageVersion(version: DbPageVersion): PageVersion {
+  return {
+    imageUrl: version.image_url,
+    generatedAt: version.generated_at,
+  };
+}
+
+export function mapDbToPage(page: DbComicPage): Page {
+  return {
+    pageNumber: page.page_number,
+    selectedVersionIndex: page.selected_version_index,
+    versions: (page.page_versions ?? [])
+      .sort((a, b) => a.version_index - b.version_index)
+      .map(mapDbToPageVersion),
+  };
+}
+
+export function mapDbToComic(
+  comic: DbComic,
+  pages: DbComicPage[] | null
+): Comic {
+  return {
+    id: comic.id,
+    userId: comic.user_id,
+    status: comic.status,
+    createdAt: comic.created_at,
+    updatedAt: comic.updated_at,
+    prompt: comic.prompt,
+    artStyle: comic.art_style,
+    customStylePrompt: comic.custom_style_prompt ?? undefined,
+    pageCount: comic.page_count,
+    followUpQuestions: comic.follow_up_questions ?? undefined,
+    followUpAnswers: comic.follow_up_answers ?? undefined,
+    script: comic.script ?? undefined,
+    generationMode: comic.generation_mode ?? undefined,
+    currentPageIndex: comic.current_page_index,
+    pages: (pages ?? []).map(mapDbToPage),
+  };
+}
+
+export function mapDbToSummary(
+  comic: DbComic,
+  firstPage?: DbComicPage
+): ComicSummary {
+  let thumbnailUrl: string | null = null;
+  if (firstPage) {
+    const selected = (firstPage.page_versions ?? []).find(
+      (v) => v.version_index === firstPage.selected_version_index
+    );
+    thumbnailUrl = selected?.image_url ?? null;
+  }
+
+  return {
+    id: comic.id,
+    status: comic.status,
+    createdAt: comic.created_at,
+    updatedAt: comic.updated_at,
+    title: comic.script?.title ?? null,
+    artStyle: comic.art_style,
+    customStylePrompt: comic.custom_style_prompt ?? undefined,
+    pageCount: comic.page_count,
+    thumbnailUrl,
+  };
+}
+
+export function mapComicToDb(
+  comic: Partial<Comic> & { id: string }
+): Partial<DbComic> & { id: string } {
+  const db: Partial<DbComic> & { id: string } = { id: comic.id };
+
+  if (comic.userId !== undefined) db.user_id = comic.userId;
+  if (comic.status !== undefined) db.status = comic.status;
+  if (comic.prompt !== undefined) db.prompt = comic.prompt;
+  if (comic.artStyle !== undefined) db.art_style = comic.artStyle;
+  if (comic.customStylePrompt !== undefined)
+    db.custom_style_prompt = comic.customStylePrompt;
+  if (comic.pageCount !== undefined) db.page_count = comic.pageCount;
+  if (comic.followUpQuestions !== undefined)
+    db.follow_up_questions = comic.followUpQuestions;
+  if (comic.followUpAnswers !== undefined)
+    db.follow_up_answers = comic.followUpAnswers;
+  if (comic.script !== undefined) db.script = comic.script;
+  if (comic.generationMode !== undefined)
+    db.generation_mode = comic.generationMode;
+  if (comic.currentPageIndex !== undefined)
+    db.current_page_index = comic.currentPageIndex;
+
+  return db;
+}
+
+// ---------------------------------------------------------------------------
+// Query functions
+// ---------------------------------------------------------------------------
+
+export async function getComic(id: string): Promise<Comic | null> {
+  const { data: comic, error } = await supabaseAdmin
+    .from("comics")
+    .select("*")
+    .eq("id", id)
+    .single();
+
+  if (error || !comic) return null;
+
+  const { data: pages } = await supabaseAdmin
+    .from("comic_pages")
+    .select("*, page_versions(*)")
+    .eq("comic_id", id)
+    .order("page_number");
+
+  return mapDbToComic(comic as DbComic, pages as DbComicPage[] | null);
+}
+
+export async function saveComic(
+  comic: Partial<Comic> & { id: string }
+): Promise<void> {
+  const { error } = await supabaseAdmin
+    .from("comics")
+    .upsert(mapComicToDb(comic));
+
+  if (error) throw error;
+}
+
+export async function getUserComics(userId: string): Promise<ComicSummary[]> {
+  const { data: comics, error } = await supabaseAdmin
+    .from("comics")
+    .select("*")
+    .eq("user_id", userId)
+    .order("created_at", { ascending: false });
+
+  if (error) throw error;
+  if (!comics || comics.length === 0) return [];
+
+  const comicIds = (comics as DbComic[]).map((c) => c.id);
+  const { data: firstPages } = await supabaseAdmin
+    .from("comic_pages")
+    .select("*, page_versions(*)")
+    .in("comic_id", comicIds)
+    .eq("page_number", 1);
+
+  const firstPageByComicId = new Map(
+    ((firstPages ?? []) as DbComicPage[]).map((p) => [p.comic_id, p])
+  );
+
+  return (comics as DbComic[]).map((comic) =>
+    mapDbToSummary(comic, firstPageByComicId.get(comic.id))
+  );
+}
+
+export async function deleteComic(id: string): Promise<void> {
+  const { error } = await supabaseAdmin.from("comics").delete().eq("id", id);
+  if (error) throw error;
+}
+
+export async function getOrCreatePage(
+  comicId: string,
+  pageNumber: number
+): Promise<string> {
+  const { data, error } = await supabaseAdmin
+    .from("comic_pages")
+    .upsert(
+      { comic_id: comicId, page_number: pageNumber },
+      { onConflict: "comic_id,page_number" }
+    )
+    .select("id")
+    .single();
+
+  if (error) throw error;
+  return (data as { id: string }).id;
+}
+
+export async function getPageVersionCount(pageId: string): Promise<number> {
+  const { count, error } = await supabaseAdmin
+    .from("page_versions")
+    .select("*", { count: "exact", head: true })
+    .eq("page_id", pageId);
+
+  if (error) throw error;
+  return count ?? 0;
+}
+
+export async function addPageVersion(
+  pageId: string,
+  versionIndex: number,
+  imageUrl: string
+): Promise<void> {
+  const { error } = await supabaseAdmin.from("page_versions").insert({
+    page_id: pageId,
+    version_index: versionIndex,
+    image_url: imageUrl,
+  });
+
+  if (error) throw error;
+}
+
+export async function selectPageVersion(
+  comicId: string,
+  pageNumber: number,
+  versionIndex: number
+): Promise<void> {
+  const { error } = await supabaseAdmin
+    .from("comic_pages")
+    .update({ selected_version_index: versionIndex })
+    .eq("comic_id", comicId)
+    .eq("page_number", pageNumber);
+
+  if (error) throw error;
+}

--- a/src/backend/lib/supabase/middleware.ts
+++ b/src/backend/lib/supabase/middleware.ts
@@ -1,0 +1,15 @@
+import { createRequestClient } from "./server";
+
+export async function getOptionalUser() {
+  const supabase = await createRequestClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  return user; // null if not logged in
+}
+
+export async function getRequiredUser() {
+  const user = await getOptionalUser();
+  if (!user) throw new Error("AUTH_REQUIRED");
+  return user;
+}

--- a/src/backend/lib/supabase/server.ts
+++ b/src/backend/lib/supabase/server.ts
@@ -1,0 +1,28 @@
+import { createServerClient } from "@supabase/ssr";
+import { createClient } from "@supabase/supabase-js";
+import { cookies } from "next/headers";
+
+export async function createRequestClient() {
+  const cookieStore = await cookies();
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll();
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value, options }) =>
+            cookieStore.set(name, value, options)
+          );
+        },
+      },
+    }
+  );
+}
+
+export const supabaseAdmin = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+);

--- a/src/backend/lib/supabase/storage.ts
+++ b/src/backend/lib/supabase/storage.ts
@@ -1,0 +1,35 @@
+import { supabaseAdmin } from "./server";
+
+const BUCKET = "comics";
+
+export async function uploadImage(
+  comicId: string,
+  pageNumber: number,
+  versionIndex: number,
+  imageBuffer: Buffer
+): Promise<string> {
+  const path = `${comicId}/page-${pageNumber}-v${versionIndex}.png`;
+
+  const { error } = await supabaseAdmin.storage
+    .from(BUCKET)
+    .upload(path, imageBuffer, {
+      contentType: "image/png",
+      upsert: true,
+    });
+
+  if (error) throw error;
+
+  const { data } = supabaseAdmin.storage.from(BUCKET).getPublicUrl(path);
+  return data.publicUrl;
+}
+
+export async function deleteComicImages(comicId: string): Promise<void> {
+  const { data: files } = await supabaseAdmin.storage
+    .from(BUCKET)
+    .list(comicId);
+
+  if (files && files.length > 0) {
+    const paths = files.map((f) => `${comicId}/${f.name}`);
+    await supabaseAdmin.storage.from(BUCKET).remove(paths);
+  }
+}

--- a/src/backend/lib/types.ts
+++ b/src/backend/lib/types.ts
@@ -1,0 +1,95 @@
+export type ComicStatus =
+  | "input"             // Comic created, awaiting follow-up answers or skip
+  | "script_pending"    // Follow-ups submitted, script not yet generated
+  | "script_draft"      // Script generated, awaiting user review
+  | "script_approved"   // Script approved, generation mode selected
+  | "generating"        // Image generation in progress
+  | "complete";         // All pages generated
+
+export type GenerationMode = "supervised" | "automated";
+
+export type ArtStylePreset =
+  | "manga"
+  | "western_comic"
+  | "watercolor_storybook"
+  | "minimalist_flat"
+  | "vintage_newspaper"
+  | "custom";
+
+export interface Comic {
+  id: string;                         // UUID
+  userId: string | null;              // Supabase auth user ID, null for guests
+  status: ComicStatus;
+  createdAt: string;                  // ISO 8601
+  updatedAt: string;                  // ISO 8601
+
+  // User input
+  prompt: string;
+  artStyle: ArtStylePreset;
+  customStylePrompt?: string;         // Only when artStyle === "custom"
+  pageCount: number;                  // 1–15
+
+  // Follow-up questions
+  followUpQuestions?: FollowUpQuestion[];
+  followUpAnswers?: Record<string, string>; // questionId -> answer
+
+  // Script
+  script?: Script;
+
+  // Generation
+  generationMode?: GenerationMode;
+  pages: Page[];
+  currentPageIndex: number;           // Tracks progress in supervised mode
+}
+
+export interface FollowUpQuestion {
+  id: string;                         // e.g. "q1", "q2"
+  question: string;
+}
+
+export interface Script {
+  title: string;
+  synopsis: string;
+  pages: ScriptPage[];
+}
+
+export interface ScriptPage {
+  pageNumber: number;                 // 1-indexed
+  panels: ScriptPanel[];
+}
+
+export interface ScriptPanel {
+  panelNumber: number;                // 1-indexed within the page
+  description: string;                // Visual description (used for image gen prompt)
+  dialogue: DialogueLine[];
+  caption?: string;                   // Narrator text
+}
+
+export interface DialogueLine {
+  speaker: string;
+  text: string;
+}
+
+export interface Page {
+  pageNumber: number;
+  versions: PageVersion[];            // Max 4 (original + 3 regenerations)
+  selectedVersionIndex: number;       // Which version the user picked
+}
+
+export interface PageVersion {
+  imageUrl: string;                   // Supabase Storage public URL
+  generatedAt: string;                // ISO 8601
+}
+
+// Lightweight summary used for the library grid
+export interface ComicSummary {
+  id: string;
+  status: ComicStatus;
+  createdAt: string;
+  updatedAt: string;
+  title: string | null;               // From script, null if no script yet
+  artStyle: ArtStylePreset;
+  customStylePrompt?: string;
+  pageCount: number;
+  thumbnailUrl: string | null;        // First page selected version image, null if no pages yet
+}

--- a/supabase/migrations/001_initial_schema.sql
+++ b/supabase/migrations/001_initial_schema.sql
@@ -1,0 +1,68 @@
+-- Comics table
+create table comics (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references auth.users(id) on delete set null,
+  status text not null default 'input'
+    check (status in ('input', 'script_pending', 'script_draft', 'script_approved', 'generating', 'complete')),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+
+  -- User input
+  prompt text not null,
+  art_style text not null
+    check (art_style in ('manga', 'western_comic', 'watercolor_storybook', 'minimalist_flat', 'vintage_newspaper', 'custom')),
+  custom_style_prompt text,
+  page_count int not null check (page_count between 1 and 15),
+
+  -- Follow-up questions and answers (stored as JSONB)
+  follow_up_questions jsonb,  -- Array of { id, question }
+  follow_up_answers jsonb,    -- Object of { questionId: answer }
+
+  -- Script (stored as JSONB)
+  script jsonb,               -- { title, synopsis, pages: [...] }
+
+  -- Generation
+  generation_mode text check (generation_mode in ('supervised', 'automated')),
+  current_page_index int not null default 0
+);
+
+-- Pages table (one row per page)
+create table comic_pages (
+  id uuid primary key default gen_random_uuid(),
+  comic_id uuid not null references comics(id) on delete cascade,
+  page_number int not null,
+  selected_version_index int not null default 0,
+  created_at timestamptz not null default now(),
+
+  unique (comic_id, page_number)
+);
+
+-- Page versions table (one row per generated version of a page)
+create table page_versions (
+  id uuid primary key default gen_random_uuid(),
+  page_id uuid not null references comic_pages(id) on delete cascade,
+  version_index int not null,
+  image_url text not null,
+  generated_at timestamptz not null default now(),
+
+  unique (page_id, version_index)
+);
+
+-- Indexes
+create index idx_comics_user_id on comics(user_id);
+create index idx_comics_status on comics(status);
+create index idx_comic_pages_comic_id on comic_pages(comic_id);
+create index idx_page_versions_page_id on page_versions(page_id);
+
+-- Updated_at trigger
+create or replace function update_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger comics_updated_at
+  before update on comics
+  for each row execute function update_updated_at();

--- a/supabase/migrations/002_rls_policies.sql
+++ b/supabase/migrations/002_rls_policies.sql
@@ -1,0 +1,29 @@
+alter table comics enable row level security;
+alter table comic_pages enable row level security;
+alter table page_versions enable row level security;
+
+-- Comics: anyone can read (for sharing), only owner can update/delete
+create policy "Comics are publicly readable"
+  on comics for select using (true);
+
+create policy "Anyone can insert comics"
+  on comics for insert with check (true);
+
+create policy "Anyone can update comics"
+  on comics for update using (true);
+
+-- Delete restricted to owner (enforced in application code via service role)
+-- RLS for delete uses service role key, so application code handles ownership checks
+
+-- Pages and versions: readable by anyone (needed for shared comic viewer)
+create policy "Pages are publicly readable"
+  on comic_pages for select using (true);
+
+create policy "Pages writeable via service role"
+  on comic_pages for all using (true);
+
+create policy "Versions are publicly readable"
+  on page_versions for select using (true);
+
+create policy "Versions writeable via service role"
+  on page_versions for all using (true);


### PR DESCRIPTION
## Summary
- `POST /api/comic/[id]/refine`: stores follow-up answers, transitions status to script_pending
- `POST /api/comic/[id]/script/generate`: generates full script via Gemini, transitions to script_draft
- `PUT /api/comic/[id]/approve`: validates and stores approved script + generation mode, transitions to script_approved
- `GET /api/comic/[id]`: returns full comic object
- Status machine enforcement on all routes
- Swagger spec updated with all 4 endpoints

## Test plan
- [ ] Full flow: create → refine → generate script → approve
- [ ] Status errors return 400 when called out of order
- [ ] `npm run lint` clean