### PR TITLE
feat(backend): Supabase Auth setup and middleware (#20)

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,36 @@
+import { createServerClient } from "@supabase/ssr";
+import { NextResponse, type NextRequest } from "next/server";
+
+export async function middleware(request: NextRequest) {
+  let supabaseResponse = NextResponse.next({ request });
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll();
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value }) => request.cookies.set(name, value));
+          supabaseResponse = NextResponse.next({ request });
+          cookiesToSet.forEach(({ name, value, options }) =>
+            supabaseResponse.cookies.set(name, value, options)
+          );
+        },
+      },
+    }
+  );
+
+  // Refresh session so it doesn't expire — do not remove this call
+  await supabase.auth.getUser();
+
+  return supabaseResponse;
+}
+
+export const config = {
+  matcher: [
+    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+  ],
+};

--- a/src/backend/lib/supabase/__tests__/middleware.test.ts
+++ b/src/backend/lib/supabase/__tests__/middleware.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockGetUser = vi.fn();
+
+vi.mock("../server", () => ({
+  createRequestClient: vi.fn().mockResolvedValue({
+    auth: { getUser: mockGetUser },
+  }),
+}));
+
+import { getOptionalUser, getRequiredUser } from "../middleware";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getOptionalUser", () => {
+  it("returns the user when a session exists", async () => {
+    const user = { id: "u1", email: "test@example.com" };
+    mockGetUser.mockResolvedValue({ data: { user } });
+
+    const result = await getOptionalUser();
+
+    expect(result).toEqual(user);
+  });
+
+  it("returns null when no session exists", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+
+    const result = await getOptionalUser();
+
+    expect(result).toBeNull();
+  });
+});
+
+describe("getRequiredUser", () => {
+  it("returns the user when a session exists", async () => {
+    const user = { id: "u1", email: "test@example.com" };
+    mockGetUser.mockResolvedValue({ data: { user } });
+
+    const result = await getRequiredUser();
+
+    expect(result).toEqual(user);
+  });
+
+  it("throws AUTH_REQUIRED when no session exists", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+
+    await expect(getRequiredUser()).rejects.toThrow("AUTH_REQUIRED");
+  });
+});


### PR DESCRIPTION
## Summary
- Supabase server client (`createRequestClient`) and admin client (`supabaseAdmin`)
- Auth middleware helpers: `getOptionalUser()` and `getRequiredUser()`
- Root session middleware to refresh auth cookies on every request
- Unit tests for auth helpers

## Test plan
- [ ] `getOptionalUser()` returns null when unauthenticated
- [ ] `getRequiredUser()` throws `AUTH_REQUIRED` when unauthenticated
- [ ] Session middleware refreshes cookies correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)