### PR TITLE
feat(backend): supervised mode API routes (#22)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
+nano-banana-requests.log
 
 # env files (can opt-in for committing if needed)
 .env*

--- a/src/app/api/comic/[id]/page/generate/route.ts
+++ b/src/app/api/comic/[id]/page/generate/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from "next/server";
+import { generatePage } from "@/backend/handlers/generate-page";
+
+export const maxDuration = 300;
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const body = await req.json();
+    const result = await generatePage(id, body);
+    return NextResponse.json(result, { status: 200 });
+  } catch (err) {
+    if (err instanceof Error) {
+      if (err.message.startsWith("NOT_FOUND:")) {
+        return NextResponse.json({ error: "Comic not found" }, { status: 404 });
+      }
+      if (err.message.startsWith("STATUS_ERROR:")) {
+        return NextResponse.json({ error: err.message.replace("STATUS_ERROR: ", "") }, { status: 400 });
+      }
+      if (err.message.startsWith("INVALID_INPUT:")) {
+        return NextResponse.json({ error: err.message.replace("INVALID_INPUT: ", "") }, { status: 400 });
+      }
+    }
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/comic/[id]/page/regenerate/route.ts
+++ b/src/app/api/comic/[id]/page/regenerate/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from "next/server";
+import { regeneratePage } from "@/backend/handlers/regenerate-page";
+
+export const maxDuration = 300;
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const body = await req.json();
+    const result = await regeneratePage(id, body);
+    return NextResponse.json(result, { status: 200 });
+  } catch (err) {
+    if (err instanceof Error) {
+      if (err.message.startsWith("NOT_FOUND:")) {
+        return NextResponse.json({ error: "Comic not found" }, { status: 404 });
+      }
+      if (err.message.startsWith("STATUS_ERROR:")) {
+        return NextResponse.json({ error: err.message.replace("STATUS_ERROR: ", "") }, { status: 400 });
+      }
+      if (err.message.startsWith("INVALID_INPUT:")) {
+        return NextResponse.json({ error: err.message.replace("INVALID_INPUT: ", "") }, { status: 400 });
+      }
+    }
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/comic/[id]/page/select/route.ts
+++ b/src/app/api/comic/[id]/page/select/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from "next/server";
+import { selectPage } from "@/backend/handlers/select-page";
+
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const body = await req.json();
+    const result = await selectPage(id, body);
+    return NextResponse.json(result, { status: 200 });
+  } catch (err) {
+    if (err instanceof Error) {
+      if (err.message.startsWith("NOT_FOUND:")) {
+        return NextResponse.json({ error: "Comic not found" }, { status: 404 });
+      }
+      if (err.message.startsWith("STATUS_ERROR:")) {
+        return NextResponse.json({ error: err.message.replace("STATUS_ERROR: ", "") }, { status: 400 });
+      }
+      if (err.message.startsWith("INVALID_INPUT:")) {
+        return NextResponse.json({ error: err.message.replace("INVALID_INPUT: ", "") }, { status: 400 });
+      }
+    }
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/docs/route.ts
+++ b/src/app/api/docs/route.ts
@@ -162,6 +162,92 @@ const spec = {
         },
       },
     },
+    "/api/comic/{id}/page/generate": {
+      post: {
+        summary: "Generate page image",
+        description: "Generates a single page image in supervised mode. Generates a character sheet on first call if not already created. Transitions status to 'generating'. Long-running — maxDuration 300s.",
+        tags: ["Generation"],
+        parameters: [{ name: "id", in: "path", required: true, schema: { type: "string", format: "uuid" } }],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["pageNumber"],
+                properties: {
+                  pageNumber: { type: "integer", minimum: 1, example: 1 },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          "200": { description: "Page generated", content: { "application/json": { schema: { type: "object", properties: { page: { type: "object" } } } } } },
+          "400": { description: "Validation or status error" },
+          "404": { description: "Comic not found" },
+          "500": { description: "Internal server error" },
+        },
+      },
+    },
+    "/api/comic/{id}/page/regenerate": {
+      post: {
+        summary: "Regenerate page image",
+        description: "Generates a new version of a page. Enforces max 3 regenerations (4 total versions). Auto-selects the new version. Optional feedback is appended as director's notes to the prompt. Long-running — maxDuration 300s.",
+        tags: ["Generation"],
+        parameters: [{ name: "id", in: "path", required: true, schema: { type: "string", format: "uuid" } }],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["pageNumber"],
+                properties: {
+                  pageNumber: { type: "integer", minimum: 1, example: 1 },
+                  feedback: { type: "string", nullable: true, example: "Make the colours warmer and the character look more surprised" },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          "200": { description: "Page regenerated", content: { "application/json": { schema: { type: "object", properties: { page: { type: "object" } } } } } },
+          "400": { description: "Validation, status, or limit error" },
+          "404": { description: "Comic not found" },
+          "500": { description: "Internal server error" },
+        },
+      },
+    },
+    "/api/comic/{id}/page/select": {
+      put: {
+        summary: "Select page version",
+        description: "Sets the selectedVersionIndex on a page. Transitions comic status to 'complete' if this is the last page.",
+        tags: ["Generation"],
+        parameters: [{ name: "id", in: "path", required: true, schema: { type: "string", format: "uuid" } }],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["pageNumber", "versionIndex"],
+                properties: {
+                  pageNumber: { type: "integer", minimum: 1, example: 1 },
+                  versionIndex: { type: "integer", minimum: 0, example: 0 },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          "200": { description: "Version selected", content: { "application/json": { schema: { type: "object", properties: { success: { type: "boolean" }, complete: { type: "boolean" } } } } } },
+          "400": { description: "Validation or status error" },
+          "404": { description: "Comic not found" },
+          "500": { description: "Internal server error" },
+        },
+      },
+    },
     "/api/comic/random-idea": {
       get: {
         summary: "Generate random idea",

--- a/src/backend/handlers/generate-page.ts
+++ b/src/backend/handlers/generate-page.ts
@@ -1,0 +1,119 @@
+import type { Page, PageVersion } from "@/backend/lib/types";
+import { getComic, saveComic, getOrCreatePage, addPageVersion } from "@/backend/lib/db";
+import { uploadImage, uploadCharacterSheet } from "@/backend/lib/supabase/storage";
+import { buildCharacterSheetPrompt, buildPageImagePrompt } from "@/backend/lib/ai/prompts";
+import { generatePageImage, generateCharacterSheet } from "@/backend/lib/ai/image-generator";
+
+interface GeneratePageResult {
+  page: Page;
+}
+
+function validateBody(body: unknown): { pageNumber: number } {
+  if (!body || typeof body !== "object") {
+    throw new Error("INVALID_INPUT: Request body is required");
+  }
+  const { pageNumber } = body as Record<string, unknown>;
+  if (typeof pageNumber !== "number" || !Number.isInteger(pageNumber) || pageNumber < 1) {
+    throw new Error("INVALID_INPUT: pageNumber must be a positive integer");
+  }
+  return { pageNumber };
+}
+
+async function fetchBuffer(url: string): Promise<Buffer> {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`Failed to fetch image: ${res.status}`);
+  return Buffer.from(await res.arrayBuffer());
+}
+
+export async function generatePage(id: string, body: unknown): Promise<GeneratePageResult> {
+  const { pageNumber } = validateBody(body);
+
+  const comic = await getComic(id);
+  if (!comic) throw new Error("NOT_FOUND: Comic not found");
+  if (comic.generationMode !== "supervised") {
+    throw new Error("STATUS_ERROR: This endpoint is for supervised mode only");
+  }
+  if (comic.status !== "script_approved" && comic.status !== "generating") {
+    throw new Error(`STATUS_ERROR: Cannot generate page in status "${comic.status}"`);
+  }
+  if (!comic.script) {
+    throw new Error("STATUS_ERROR: Comic has no script");
+  }
+  if (pageNumber > comic.pageCount) {
+    throw new Error(`INVALID_INPUT: pageNumber ${pageNumber} exceeds pageCount ${comic.pageCount}`);
+  }
+
+  const scriptPage = comic.script.pages.find((p) => p.pageNumber === pageNumber);
+  if (!scriptPage) {
+    throw new Error(`STATUS_ERROR: Page ${pageNumber} not found in script`);
+  }
+
+  // Generate character sheet on first page if not already created
+  let characterSheetUrl = comic.characterSheetUrl;
+  if (!characterSheetUrl) {
+    try {
+      const sheetPrompt = buildCharacterSheetPrompt(
+        comic.script,
+        comic.artStyle,
+        comic.customStylePrompt
+      );
+      const sheetBuffer = await generateCharacterSheet(sheetPrompt);
+      characterSheetUrl = await uploadCharacterSheet(id, sheetBuffer);
+      await saveComic({ id, characterSheetUrl });
+      console.log(`[generate-page] Character sheet generated for comic ${id}`);
+    } catch (err) {
+      console.warn(`[generate-page] Character sheet generation failed, continuing without: ${err}`);
+    }
+  }
+
+  // Build reference buffers: character sheet + previous page's selected version
+  const refs: Buffer[] = [];
+  let hasCharacterSheet = false;
+  if (characterSheetUrl) {
+    try {
+      refs.push(await fetchBuffer(characterSheetUrl));
+      hasCharacterSheet = true;
+    } catch {
+      // Non-fatal
+    }
+  }
+
+  let hasPreviousPage = false;
+  const prevPage = comic.pages.find((p) => p.pageNumber === pageNumber - 1);
+  if (prevPage) {
+    const selectedVersion = prevPage.versions[prevPage.selectedVersionIndex];
+    if (selectedVersion) {
+      try {
+        refs.push(await fetchBuffer(selectedVersion.imageUrl));
+        hasPreviousPage = true;
+      } catch {
+        // Non-fatal
+      }
+    }
+  }
+
+  const prompt = buildPageImagePrompt(
+    scriptPage,
+    comic.artStyle,
+    comic.script.title,
+    comic.pageCount,
+    comic.customStylePrompt,
+    hasCharacterSheet,
+    hasPreviousPage,
+    comic.script.characters
+  );
+
+  const imageBuffer = await generatePageImage(prompt, refs);
+  const versionIndex = 0;
+  const imageUrl = await uploadImage(id, pageNumber, versionIndex, imageBuffer);
+
+  const pageId = await getOrCreatePage(id, pageNumber);
+  await addPageVersion(pageId, versionIndex, imageUrl);
+
+  await saveComic({ id, status: "generating", currentPageIndex: pageNumber });
+
+  const version: PageVersion = { imageUrl, generatedAt: new Date().toISOString() };
+  const page: Page = { pageNumber, versions: [version], selectedVersionIndex: 0 };
+
+  return { page };
+}

--- a/src/backend/handlers/regenerate-page.ts
+++ b/src/backend/handlers/regenerate-page.ts
@@ -1,0 +1,129 @@
+import type { Page, PageVersion } from "@/backend/lib/types";
+import { getComic, getOrCreatePage, addPageVersion, selectPageVersion } from "@/backend/lib/db";
+import { uploadImage } from "@/backend/lib/supabase/storage";
+import { buildPageImagePrompt } from "@/backend/lib/ai/prompts";
+import { generatePageImage } from "@/backend/lib/ai/image-generator";
+
+const MAX_VERSIONS = 4;
+
+interface RegeneratePageResult {
+  page: Page;
+}
+
+interface ValidatedBody {
+  pageNumber: number;
+  feedback?: string;
+}
+
+function validateBody(body: unknown): ValidatedBody {
+  if (!body || typeof body !== "object") {
+    throw new Error("INVALID_INPUT: Request body is required");
+  }
+  const { pageNumber, feedback } = body as Record<string, unknown>;
+  if (typeof pageNumber !== "number" || !Number.isInteger(pageNumber) || pageNumber < 1) {
+    throw new Error("INVALID_INPUT: pageNumber must be a positive integer");
+  }
+  if (feedback !== undefined && typeof feedback !== "string") {
+    throw new Error("INVALID_INPUT: feedback must be a string");
+  }
+  const trimmed = typeof feedback === "string" ? feedback.trim() : undefined;
+  return { pageNumber, feedback: trimmed || undefined };
+}
+
+async function fetchBuffer(url: string): Promise<Buffer> {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`Failed to fetch image: ${res.status}`);
+  return Buffer.from(await res.arrayBuffer());
+}
+
+export async function regeneratePage(
+  id: string,
+  body: unknown
+): Promise<RegeneratePageResult> {
+  const { pageNumber, feedback } = validateBody(body);
+
+  const comic = await getComic(id);
+  if (!comic) throw new Error("NOT_FOUND: Comic not found");
+  if (comic.generationMode !== "supervised") {
+    throw new Error("STATUS_ERROR: This endpoint is for supervised mode only");
+  }
+  if (comic.status !== "generating") {
+    throw new Error(`STATUS_ERROR: Cannot regenerate page in status "${comic.status}"`);
+  }
+  if (!comic.script) {
+    throw new Error("STATUS_ERROR: Comic has no script");
+  }
+
+  const page = comic.pages.find((p) => p.pageNumber === pageNumber);
+  if (!page) {
+    throw new Error(`STATUS_ERROR: Page ${pageNumber} has not been generated yet`);
+  }
+  if (page.versions.length >= MAX_VERSIONS) {
+    throw new Error(
+      `STATUS_ERROR: Maximum regeneration limit (${MAX_VERSIONS - 1}) reached for page ${pageNumber}`
+    );
+  }
+
+  const scriptPage = comic.script.pages.find((p) => p.pageNumber === pageNumber);
+  if (!scriptPage) {
+    throw new Error(`STATUS_ERROR: Page ${pageNumber} not found in script`);
+  }
+
+  // Build reference buffers: character sheet + previous page's selected version
+  const refs: Buffer[] = [];
+  let hasCharacterSheet = false;
+  if (comic.characterSheetUrl) {
+    try {
+      refs.push(await fetchBuffer(comic.characterSheetUrl));
+      hasCharacterSheet = true;
+    } catch {
+      // Non-fatal
+    }
+  }
+
+  let hasPreviousPage = false;
+  const prevPage = comic.pages.find((p) => p.pageNumber === pageNumber - 1);
+  if (prevPage) {
+    const selectedVersion = prevPage.versions[prevPage.selectedVersionIndex];
+    if (selectedVersion) {
+      try {
+        refs.push(await fetchBuffer(selectedVersion.imageUrl));
+        hasPreviousPage = true;
+      } catch {
+        // Non-fatal
+      }
+    }
+  }
+
+  let prompt = buildPageImagePrompt(
+    scriptPage,
+    comic.artStyle,
+    comic.script.title,
+    comic.pageCount,
+    comic.customStylePrompt,
+    hasCharacterSheet,
+    hasPreviousPage,
+    comic.script.characters
+  );
+
+  if (feedback) {
+    prompt += `\n\nDIRECTOR'S NOTES (apply these changes to the regenerated page):\n${feedback}`;
+  }
+
+  const imageBuffer = await generatePageImage(prompt, refs);
+  const versionIndex = page.versions.length;
+  const imageUrl = await uploadImage(id, pageNumber, versionIndex, imageBuffer);
+
+  const pageId = await getOrCreatePage(id, pageNumber);
+  await addPageVersion(pageId, versionIndex, imageUrl);
+  await selectPageVersion(id, pageNumber, versionIndex);
+
+  const newVersion: PageVersion = { imageUrl, generatedAt: new Date().toISOString() };
+  const updatedPage: Page = {
+    pageNumber,
+    versions: [...page.versions, newVersion],
+    selectedVersionIndex: versionIndex,
+  };
+
+  return { page: updatedPage };
+}

--- a/src/backend/handlers/select-page.ts
+++ b/src/backend/handlers/select-page.ts
@@ -1,0 +1,52 @@
+import { getComic, saveComic, selectPageVersion } from "@/backend/lib/db";
+
+interface SelectPageResult {
+  success: boolean;
+  complete: boolean;
+}
+
+function validateBody(body: unknown): { pageNumber: number; versionIndex: number } {
+  if (!body || typeof body !== "object") {
+    throw new Error("INVALID_INPUT: Request body is required");
+  }
+  const { pageNumber, versionIndex } = body as Record<string, unknown>;
+  if (typeof pageNumber !== "number" || !Number.isInteger(pageNumber) || pageNumber < 1) {
+    throw new Error("INVALID_INPUT: pageNumber must be a positive integer");
+  }
+  if (typeof versionIndex !== "number" || !Number.isInteger(versionIndex) || versionIndex < 0) {
+    throw new Error("INVALID_INPUT: versionIndex must be a non-negative integer");
+  }
+  return { pageNumber, versionIndex };
+}
+
+export async function selectPage(id: string, body: unknown): Promise<SelectPageResult> {
+  const { pageNumber, versionIndex } = validateBody(body);
+
+  const comic = await getComic(id);
+  if (!comic) throw new Error("NOT_FOUND: Comic not found");
+  if (comic.generationMode !== "supervised") {
+    throw new Error("STATUS_ERROR: This endpoint is for supervised mode only");
+  }
+  if (comic.status !== "generating") {
+    throw new Error(`STATUS_ERROR: Cannot select page version in status "${comic.status}"`);
+  }
+
+  const page = comic.pages.find((p) => p.pageNumber === pageNumber);
+  if (!page) {
+    throw new Error(`STATUS_ERROR: Page ${pageNumber} has not been generated yet`);
+  }
+  if (versionIndex >= page.versions.length) {
+    throw new Error(
+      `INVALID_INPUT: versionIndex ${versionIndex} is out of range (page has ${page.versions.length} versions)`
+    );
+  }
+
+  await selectPageVersion(id, pageNumber, versionIndex);
+
+  const isLastPage = pageNumber === comic.pageCount;
+  if (isLastPage) {
+    await saveComic({ id, status: "complete" });
+  }
+
+  return { success: true, complete: isLastPage };
+}

--- a/src/backend/lib/ai/image-generator.ts
+++ b/src/backend/lib/ai/image-generator.ts
@@ -1,7 +1,35 @@
+import fs from "fs";
+import path from "path";
 import { IMAGE_ASPECT_RATIO, IMAGE_RESOLUTION } from "@/backend/lib/constants";
 import { ai } from "./gemini-client";
 
 const IMAGE_MODEL = "gemini-3-pro-image-preview";
+const LOG_FILE = path.join(process.cwd(), "nano-banana-requests.log");
+
+function logRequest(
+  prompt: string,
+  refCount: number,
+  success: boolean,
+  durationMs: number,
+  error?: string
+): void {
+  const entry = [
+    `[${new Date().toISOString()}]`,
+    `refs=${refCount}`,
+    `success=${success}`,
+    `duration=${durationMs}ms`,
+    error ? `error=${error}` : "",
+    `\n--- PROMPT ---\n${prompt}\n--- END ---\n`,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  try {
+    fs.appendFileSync(LOG_FILE, entry + "\n");
+  } catch {
+    console.warn("[image-generator] Failed to write to log file");
+  }
+}
 
 function detectMimeType(buf: Buffer): string {
   if (buf[0] === 0xff && buf[1] === 0xd8) return "image/jpeg";
@@ -24,21 +52,30 @@ export async function generatePageImage(
     { text: prompt },
   ];
 
-  const response = await ai.models.generateContent({
-    model: IMAGE_MODEL,
-    contents: [{ role: "user", parts }],
-    config: {
-      responseModalities: ["IMAGE"],
-      imageConfig: {
-        aspectRatio: IMAGE_ASPECT_RATIO,
-        imageSize: IMAGE_RESOLUTION,
+  const start = Date.now();
+  let response;
+  try {
+    response = await ai.models.generateContent({
+      model: IMAGE_MODEL,
+      contents: [{ role: "user", parts }],
+      config: {
+        responseModalities: ["IMAGE"],
+        imageConfig: {
+          aspectRatio: IMAGE_ASPECT_RATIO,
+          imageSize: IMAGE_RESOLUTION,
+        },
       },
-    },
-  });
+    });
+  } catch (err) {
+    logRequest(prompt, referenceBuffers.length, false, Date.now() - start, String(err));
+    throw err;
+  }
 
+  const duration = Date.now() - start;
   const responseParts = response.candidates?.[0]?.content?.parts ?? [];
   for (const part of responseParts) {
     if ((part as { inlineData?: { data?: string } }).inlineData?.data) {
+      logRequest(prompt, referenceBuffers.length, true, duration);
       return Buffer.from(
         (part as { inlineData: { data: string } }).inlineData.data,
         "base64"
@@ -46,7 +83,8 @@ export async function generatePageImage(
     }
   }
 
-  throw new Error("No image returned from Nano Banana Pro");
+  logRequest(prompt, referenceBuffers.length, false, duration, "No image in response");
+  throw new Error("No image returned from image generation model");
 }
 
 export async function generateCharacterSheet(prompt: string): Promise<Buffer> {


### PR DESCRIPTION
## Summary
- `POST /api/comic/{id}/page/generate` — generates a single page image; auto-generates character sheet on first call
- `POST /api/comic/{id}/page/regenerate` — regenerates a page with optional feedback (DIRECTOR'S NOTES pattern); max 4 versions per page
- `PUT /api/comic/{id}/page/select` — selects a page version; transitions comic to `complete` on last page
- Multimodal image generation: character sheet + previous page passed as reference images
- File logging of every Gemini image request to `nano-banana-requests.log`

## Test plan
- [ ] Generate page returns `{ page }` with correct structure
- [ ] Character sheet generated on first page, reused for subsequent pages
- [ ] Regenerate enforces 4-version limit (returns 400 on 5th attempt)
- [ ] Feedback appended as DIRECTOR'S NOTES to prompt
- [ ] Select on last page transitions status to `complete`

🤖 Generated with [Claude Code](https://claude.com/claude-code)