### PR TITLE
feat(backend): library API and delete endpoint (#23)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,6 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 .playwright-mcp
-docs
+/docs
 
 /references

--- a/src/app/api/comic/[id]/route.ts
+++ b/src/app/api/comic/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getComic } from "@/backend/handlers/get-comic";
+import { deleteComic } from "@/backend/handlers/delete-comic";
 
 export async function GET(
   _req: NextRequest,
@@ -12,6 +13,30 @@ export async function GET(
   } catch (err) {
     if (err instanceof Error && err.message.startsWith("NOT_FOUND:")) {
       return NextResponse.json({ error: "Comic not found" }, { status: 404 });
+    }
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const result = await deleteComic(id);
+    return NextResponse.json(result, { status: 200 });
+  } catch (err) {
+    if (err instanceof Error) {
+      if (err.message === "AUTH_REQUIRED") {
+        return NextResponse.json({ error: "Authentication required" }, { status: 401 });
+      }
+      if (err.message.startsWith("NOT_FOUND:")) {
+        return NextResponse.json({ error: "Comic not found" }, { status: 404 });
+      }
+      if (err.message.startsWith("FORBIDDEN:")) {
+        return NextResponse.json({ error: "You do not own this comic" }, { status: 403 });
+      }
     }
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }

--- a/src/app/api/docs/route.ts
+++ b/src/app/api/docs/route.ts
@@ -8,6 +8,16 @@ const spec = {
     description: "Backend API for the Comicly comic generation app",
   },
   servers: [{ url: process.env.NEXT_PUBLIC_BASE_URL ?? "http://localhost:3000" }],
+  components: {
+    securitySchemes: {
+      bearerAuth: {
+        type: "http",
+        scheme: "bearer",
+        bearerFormat: "JWT",
+        description: "Supabase JWT. Get it from browser DevTools → Application → Local Storage → sb-<project>-auth-token → access_token",
+      },
+    },
+  },
   paths: {
     "/api/comic": {
       post: {
@@ -60,19 +70,6 @@ const spec = {
             },
           },
           "400": { description: "Validation error", content: { "application/json": { schema: { type: "object", properties: { error: { type: "string" } } } } } },
-          "500": { description: "Internal server error" },
-        },
-      },
-    },
-    "/api/comic/{id}": {
-      get: {
-        summary: "Get comic",
-        description: "Returns the full comic object. No auth required.",
-        tags: ["Comic"],
-        parameters: [{ name: "id", in: "path", required: true, schema: { type: "string", format: "uuid" } }],
-        responses: {
-          "200": { description: "Comic object", content: { "application/json": { schema: { type: "object", properties: { comic: { type: "object" } } } } } },
-          "404": { description: "Comic not found" },
           "500": { description: "Internal server error" },
         },
       },
@@ -157,6 +154,58 @@ const spec = {
         responses: {
           "200": { description: "All pages generated", content: { "application/json": { schema: { type: "object", properties: { comic: { type: "object" } } } } } },
           "400": { description: "Status or mode error" },
+          "404": { description: "Comic not found" },
+          "500": { description: "Internal server error" },
+        },
+      },
+    },
+    "/api/library": {
+      get: {
+        summary: "Get user library",
+        description: "Returns all comics belonging to the authenticated user, ordered by creation date descending. Requires authentication.",
+        tags: ["Library"],
+        security: [{ bearerAuth: [] }],
+        responses: {
+          "200": {
+            description: "User's comics",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    comics: { type: "array", items: { type: "object" } },
+                  },
+                },
+              },
+            },
+          },
+          "401": { description: "Authentication required" },
+          "500": { description: "Internal server error" },
+        },
+      },
+    },
+    "/api/comic/{id}": {
+      get: {
+        summary: "Get comic",
+        description: "Returns the full comic object. No auth required.",
+        tags: ["Comic"],
+        parameters: [{ name: "id", in: "path", required: true, schema: { type: "string", format: "uuid" } }],
+        responses: {
+          "200": { description: "Comic object", content: { "application/json": { schema: { type: "object", properties: { comic: { type: "object" } } } } } },
+          "404": { description: "Comic not found" },
+          "500": { description: "Internal server error" },
+        },
+      },
+      delete: {
+        summary: "Delete comic",
+        description: "Deletes a comic and all its associated storage images. Requires authentication and ownership.",
+        tags: ["Library"],
+        security: [{ bearerAuth: [] }],
+        parameters: [{ name: "id", in: "path", required: true, schema: { type: "string", format: "uuid" } }],
+        responses: {
+          "200": { description: "Comic deleted", content: { "application/json": { schema: { type: "object", properties: { success: { type: "boolean" } } } } } },
+          "401": { description: "Authentication required" },
+          "403": { description: "Not the comic owner" },
           "404": { description: "Comic not found" },
           "500": { description: "Internal server error" },
         },

--- a/src/app/api/library/route.ts
+++ b/src/app/api/library/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+import { getLibrary } from "@/backend/handlers/get-library";
+
+export async function GET() {
+  try {
+    const result = await getLibrary();
+    return NextResponse.json(result, { status: 200 });
+  } catch (err) {
+    if (err instanceof Error) {
+      if (err.message === "AUTH_REQUIRED") {
+        return NextResponse.json({ error: "Authentication required" }, { status: 401 });
+      }
+    }
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/backend/handlers/delete-comic.ts
+++ b/src/backend/handlers/delete-comic.ts
@@ -1,0 +1,21 @@
+import { getComic, deleteComic as deleteComicFromDb } from "@/backend/lib/db";
+import { getRequiredUser } from "@/backend/lib/supabase/middleware";
+import { deleteComicImages } from "@/backend/lib/supabase/storage";
+
+interface DeleteComicResult {
+  success: boolean;
+}
+
+export async function deleteComic(id: string): Promise<DeleteComicResult> {
+  const user = await getRequiredUser();
+
+  const comic = await getComic(id);
+  if (!comic) throw new Error("NOT_FOUND: Comic not found");
+
+  if (comic.userId !== user.id) throw new Error("FORBIDDEN: You do not own this comic");
+
+  await deleteComicImages(id);
+  await deleteComicFromDb(id);
+
+  return { success: true };
+}

--- a/src/backend/handlers/get-library.ts
+++ b/src/backend/handlers/get-library.ts
@@ -1,0 +1,13 @@
+import type { ComicSummary } from "@/backend/lib/types";
+import { getUserComics } from "@/backend/lib/db";
+import { getRequiredUser } from "@/backend/lib/supabase/middleware";
+
+interface GetLibraryResult {
+  comics: ComicSummary[];
+}
+
+export async function getLibrary(): Promise<GetLibraryResult> {
+  const user = await getRequiredUser();
+  const comics = await getUserComics(user.id);
+  return { comics };
+}

--- a/src/frontend/lib/api.ts
+++ b/src/frontend/lib/api.ts
@@ -355,6 +355,8 @@ async function mockRegeneratePage(
   const versions = [...existing, newVersion];
   _mockPageVersions.set(key, versions);
   return { page: { pageNumber, versions, selectedVersionIndex: versions.length - 1 } };
+}
+
 async function mockRegenerateScript(feedback: string): Promise<{ script: Script }> {
   void feedback;
   await delay(1200);


### PR DESCRIPTION
## Summary
- `GET /api/library` — returns all comics for the authenticated user as `ComicSummary[]`, ordered by creation date descending
- `DELETE /api/comic/{id}` — deletes a comic and all associated storage images; requires auth and ownership
- Bearer auth security scheme added to Swagger spec with padlock on protected endpoints

## Test plan
- [ ] Library returns 401 when unauthenticated
- [ ] Library returns comics belonging to the logged-in user only
- [ ] Delete returns 401 when unauthenticated
- [ ] Delete returns 403 when user does not own the comic
- [ ] Delete returns 404 when comic does not exist
- [ ] Delete removes both DB row and storage images

🤖 Generated with [Claude Code](https://claude.com/claude-code)