### PR TITLE
feat(backend): PDF export API route (#24)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@supabase/ssr": "^0.10.2",
         "@supabase/supabase-js": "^2.103.3",
         "next": "16.2.2",
+        "pdf-lib": "^1.17.1",
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "swagger-ui-react": "^5.32.4"
@@ -1649,6 +1650,24 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@pdf-lib/standard-fonts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz",
+      "integrity": "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.6"
+      }
+    },
+    "node_modules/@pdf-lib/upng": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz",
+      "integrity": "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.10"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -8518,6 +8537,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -8609,6 +8634,24 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pdf-lib": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
+      "integrity": "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@pdf-lib/standard-fonts": "^1.0.0",
+        "@pdf-lib/upng": "^1.0.1",
+        "pako": "^1.0.11",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/pdf-lib/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@supabase/ssr": "^0.10.2",
     "@supabase/supabase-js": "^2.103.3",
     "next": "16.2.2",
+    "pdf-lib": "^1.17.1",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "swagger-ui-react": "^5.32.4"

--- a/src/app/api/comic/[id]/export/pdf/route.ts
+++ b/src/app/api/comic/[id]/export/pdf/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from "next/server";
+import { exportPdf } from "@/backend/handlers/export-pdf";
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const { pdf, filename } = await exportPdf(id);
+    return new NextResponse(pdf.buffer as ArrayBuffer, {
+      status: 200,
+      headers: {
+        "Content-Type": "application/pdf",
+        "Content-Disposition": `attachment; filename="${filename}"`,
+      },
+    });
+  } catch (err) {
+    if (err instanceof Error) {
+      if (err.message.startsWith("NOT_FOUND:")) {
+        return NextResponse.json({ error: "Comic not found" }, { status: 404 });
+      }
+      if (err.message.startsWith("STATUS_ERROR:")) {
+        return NextResponse.json({ error: err.message.replace("STATUS_ERROR: ", "") }, { status: 400 });
+      }
+    }
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/docs/route.ts
+++ b/src/app/api/docs/route.ts
@@ -162,6 +162,20 @@ const spec = {
         },
       },
     },
+    "/api/comic/{id}/export/pdf": {
+      get: {
+        summary: "Export comic as PDF",
+        description: "Generates and returns a downloadable PDF of the comic. One full-page image per comic page. Comic must have status 'complete'.",
+        tags: ["Export"],
+        parameters: [{ name: "id", in: "path", required: true, schema: { type: "string", format: "uuid" } }],
+        responses: {
+          "200": { description: "PDF file", content: { "application/pdf": { schema: { type: "string", format: "binary" } } } },
+          "400": { description: "Comic is not complete" },
+          "404": { description: "Comic not found" },
+          "500": { description: "Internal server error" },
+        },
+      },
+    },
     "/api/comic/random-idea": {
       get: {
         summary: "Generate random idea",

--- a/src/backend/handlers/export-pdf.ts
+++ b/src/backend/handlers/export-pdf.ts
@@ -1,0 +1,49 @@
+import { PDFDocument } from "pdf-lib";
+import { getComic } from "@/backend/lib/db";
+
+interface ExportPdfResult {
+  pdf: Buffer;
+  filename: string;
+}
+
+export async function exportPdf(id: string): Promise<ExportPdfResult> {
+  const comic = await getComic(id);
+  if (!comic) throw new Error("NOT_FOUND: Comic not found");
+  if (comic.status !== "complete") {
+    throw new Error("STATUS_ERROR: Comic is not complete");
+  }
+
+  const pdfDoc = await PDFDocument.create();
+
+  for (const page of comic.pages) {
+    const version = page.versions[page.selectedVersionIndex];
+    if (!version) continue;
+
+    const res = await fetch(version.imageUrl);
+    if (!res.ok) throw new Error(`Failed to fetch image for page ${page.pageNumber}`);
+    const imageBytes = await res.arrayBuffer();
+
+    let pdfImage;
+    const url = version.imageUrl.toLowerCase();
+    if (url.includes(".jpg") || url.includes(".jpeg")) {
+      pdfImage = await pdfDoc.embedJpg(imageBytes);
+    } else {
+      pdfImage = await pdfDoc.embedPng(imageBytes);
+    }
+
+    const pdfPage = pdfDoc.addPage([pdfImage.width, pdfImage.height]);
+    pdfPage.drawImage(pdfImage, {
+      x: 0,
+      y: 0,
+      width: pdfImage.width,
+      height: pdfImage.height,
+    });
+  }
+
+  const pdfBytes = await pdfDoc.save();
+  const filename = `${comic.script?.title ?? "comic"}.pdf`
+    .toLowerCase()
+    .replace(/[^a-z0-9.]+/g, "-");
+
+  return { pdf: Buffer.from(pdfBytes), filename };
+}

--- a/src/frontend/lib/api.ts
+++ b/src/frontend/lib/api.ts
@@ -355,6 +355,8 @@ async function mockRegeneratePage(
   const versions = [...existing, newVersion];
   _mockPageVersions.set(key, versions);
   return { page: { pageNumber, versions, selectedVersionIndex: versions.length - 1 } };
+}
+
 async function mockRegenerateScript(feedback: string): Promise<{ script: Script }> {
   void feedback;
   await delay(1200);


### PR DESCRIPTION
## Summary
- `GET /api/comic/{id}/export/pdf` — assembles and returns a downloadable PDF using `pdf-lib`
- One full-page image per comic page (selected version)
- Returns 400 if comic status is not `complete`, 404 if not found
- No auth required — works for any accessible comic

## Test plan
- [ ] Returns `application/pdf` with correct `Content-Disposition` filename
- [ ] PDF contains one page per comic page
- [ ] Returns 400 for incomplete comics
- [ ] Returns 404 for missing comics

🤖 Generated with [Claude Code](https://claude.com/claude-code)