### PR TITLE
feat(backend): claim comic endpoint with TDD (#38)

### DIFF
--- a/src/app/api/comic/[id]/claim/route.ts
+++ b/src/app/api/comic/[id]/claim/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server";
+import { claimComic } from "@/backend/handlers/claim-comic";
+
+export async function PUT(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const result = await claimComic(id);
+    return NextResponse.json(result, { status: 200 });
+  } catch (err) {
+    if (err instanceof Error) {
+      if (err.message === "AUTH_REQUIRED") {
+        return NextResponse.json({ error: "Authentication required" }, { status: 401 });
+      }
+      if (err.message.startsWith("NOT_FOUND:")) {
+        return NextResponse.json({ error: "Comic not found" }, { status: 404 });
+      }
+      if (err.message.startsWith("FORBIDDEN:")) {
+        return NextResponse.json({ error: "You do not own this comic" }, { status: 403 });
+      }
+    }
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/docs/route.ts
+++ b/src/app/api/docs/route.ts
@@ -187,6 +187,33 @@ const spec = {
         },
       },
     },
+    "/api/comic/{id}": {
+      get: {
+        summary: "Get comic",
+        description: "Returns the full comic object. No auth required.",
+        tags: ["Comic"],
+        parameters: [{ name: "id", in: "path", required: true, schema: { type: "string", format: "uuid" } }],
+        responses: {
+          "200": { description: "Comic object", content: { "application/json": { schema: { type: "object", properties: { comic: { type: "object" } } } } } },
+          "404": { description: "Comic not found" },
+          "500": { description: "Internal server error" },
+        },
+      },
+      delete: {
+        summary: "Delete comic",
+        description: "Deletes a comic and all its associated storage images. Requires authentication and ownership.",
+        tags: ["Library"],
+        security: [{ bearerAuth: [] }],
+        parameters: [{ name: "id", in: "path", required: true, schema: { type: "string", format: "uuid" } }],
+        responses: {
+          "200": { description: "Comic deleted", content: { "application/json": { schema: { type: "object", properties: { success: { type: "boolean" } } } } } },
+          "401": { description: "Authentication required" },
+          "403": { description: "Not the comic owner" },
+          "404": { description: "Comic not found" },
+          "500": { description: "Internal server error" },
+        },
+      },
+    },
     "/api/comic/{id}/export/pdf": {
       get: {
         summary: "Export comic as PDF",
@@ -196,6 +223,11 @@ const spec = {
         responses: {
           "200": { description: "PDF file", content: { "application/pdf": { schema: { type: "string", format: "binary" } } } },
           "400": { description: "Comic is not complete" },
+          "404": { description: "Comic not found" },
+          "500": { description: "Internal server error" },
+        },
+      },
+    },
     "/api/library": {
       get: {
         summary: "Get user library",
@@ -217,6 +249,10 @@ const spec = {
             },
           },
           "401": { description: "Authentication required" },
+          "500": { description: "Internal server error" },
+        },
+      },
+    },
     "/api/comic/{id}/page/generate": {
       post: {
         summary: "Generate page image",
@@ -245,14 +281,6 @@ const spec = {
         },
       },
     },
-    "/api/comic/{id}": {
-      get: {
-        summary: "Get comic",
-        description: "Returns the full comic object. No auth required.",
-        tags: ["Comic"],
-        parameters: [{ name: "id", in: "path", required: true, schema: { type: "string", format: "uuid" } }],
-        responses: {
-          "200": { description: "Comic object", content: { "application/json": { schema: { type: "object", properties: { comic: { type: "object" } } } } } },
     "/api/comic/{id}/page/regenerate": {
       post: {
         summary: "Regenerate page image",
@@ -281,16 +309,6 @@ const spec = {
           "500": { description: "Internal server error" },
         },
       },
-      delete: {
-        summary: "Delete comic",
-        description: "Deletes a comic and all its associated storage images. Requires authentication and ownership.",
-        tags: ["Library"],
-        security: [{ bearerAuth: [] }],
-        parameters: [{ name: "id", in: "path", required: true, schema: { type: "string", format: "uuid" } }],
-        responses: {
-          "200": { description: "Comic deleted", content: { "application/json": { schema: { type: "object", properties: { success: { type: "boolean" } } } } } },
-          "401": { description: "Authentication required" },
-          "403": { description: "Not the comic owner" },
     },
     "/api/comic/{id}/page/select": {
       put: {
@@ -316,6 +334,22 @@ const spec = {
         responses: {
           "200": { description: "Version selected", content: { "application/json": { schema: { type: "object", properties: { success: { type: "boolean" }, complete: { type: "boolean" } } } } } },
           "400": { description: "Validation or status error" },
+          "404": { description: "Comic not found" },
+          "500": { description: "Internal server error" },
+        },
+      },
+    },
+    "/api/comic/{id}/claim": {
+      put: {
+        summary: "Claim guest comic",
+        description: "Links a guest-created comic (userId null) to the authenticated user's account. Idempotent if already owned by the same user.",
+        tags: ["Library"],
+        security: [{ bearerAuth: [] }],
+        parameters: [{ name: "id", in: "path", required: true, schema: { type: "string", format: "uuid" } }],
+        responses: {
+          "200": { description: "Comic claimed", content: { "application/json": { schema: { type: "object", properties: { success: { type: "boolean" } } } } } },
+          "401": { description: "Authentication required" },
+          "403": { description: "Comic is owned by another user" },
           "404": { description: "Comic not found" },
           "500": { description: "Internal server error" },
         },

--- a/src/backend/handlers/__tests__/claim-comic.test.ts
+++ b/src/backend/handlers/__tests__/claim-comic.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockGetRequiredUser = vi.fn();
+const mockGetComic = vi.fn();
+const mockClaimComicDb = vi.fn();
+
+vi.mock("@/backend/lib/supabase/middleware", () => ({
+  getRequiredUser: mockGetRequiredUser,
+}));
+
+vi.mock("@/backend/lib/db", () => ({
+  getComic: mockGetComic,
+  claimComic: mockClaimComicDb,
+}));
+
+import { claimComic } from "../claim-comic";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("claimComic handler", () => {
+  it("throws AUTH_REQUIRED when user is not authenticated", async () => {
+    mockGetRequiredUser.mockRejectedValue(new Error("AUTH_REQUIRED"));
+
+    await expect(claimComic("comic-1")).rejects.toThrow("AUTH_REQUIRED");
+  });
+
+  it("throws NOT_FOUND when comic does not exist", async () => {
+    mockGetRequiredUser.mockResolvedValue({ id: "user-1" });
+    mockGetComic.mockResolvedValue(null);
+
+    await expect(claimComic("missing-id")).rejects.toThrow("NOT_FOUND:");
+  });
+
+  it("throws FORBIDDEN when comic is owned by a different user", async () => {
+    mockGetRequiredUser.mockResolvedValue({ id: "user-1" });
+    mockGetComic.mockResolvedValue({ id: "comic-1", userId: "user-2" });
+
+    await expect(claimComic("comic-1")).rejects.toThrow("FORBIDDEN:");
+  });
+
+  it("returns success without calling db when comic is already owned by current user", async () => {
+    mockGetRequiredUser.mockResolvedValue({ id: "user-1" });
+    mockGetComic.mockResolvedValue({ id: "comic-1", userId: "user-1" });
+
+    const result = await claimComic("comic-1");
+
+    expect(result).toEqual({ success: true });
+    expect(mockClaimComicDb).not.toHaveBeenCalled();
+  });
+
+  it("claims guest comic and returns success when userId is null", async () => {
+    mockGetRequiredUser.mockResolvedValue({ id: "user-1" });
+    mockGetComic.mockResolvedValue({ id: "comic-1", userId: null });
+    mockClaimComicDb.mockResolvedValue(undefined);
+
+    const result = await claimComic("comic-1");
+
+    expect(result).toEqual({ success: true });
+    expect(mockClaimComicDb).toHaveBeenCalledWith("comic-1", "user-1");
+  });
+});

--- a/src/backend/handlers/__tests__/claim-comic.test.ts
+++ b/src/backend/handlers/__tests__/claim-comic.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const mockGetRequiredUser = vi.fn();
-const mockGetComic = vi.fn();
-const mockClaimComicDb = vi.fn();
+const { mockGetRequiredUser, mockGetComic, mockClaimComicDb } = vi.hoisted(() => ({
+  mockGetRequiredUser: vi.fn(),
+  mockGetComic: vi.fn(),
+  mockClaimComicDb: vi.fn(),
+}));
 
 vi.mock("@/backend/lib/supabase/middleware", () => ({
   getRequiredUser: mockGetRequiredUser,

--- a/src/backend/handlers/claim-comic.ts
+++ b/src/backend/handlers/claim-comic.ts
@@ -1,23 +1,17 @@
 import { getComic, claimComic as claimComicInDb } from "@/backend/lib/db";
 import { getRequiredUser } from "@/backend/lib/supabase/middleware";
 
-interface ClaimComicResult {
-  success: boolean;
-}
-
-export async function claimComic(id: string): Promise<ClaimComicResult> {
+export async function claimComic(id: string): Promise<{ success: boolean }> {
   const user = await getRequiredUser();
 
   const comic = await getComic(id);
   if (!comic) throw new Error("NOT_FOUND: Comic not found");
 
-  if (comic.userId !== null && comic.userId !== user.id) {
-    throw new Error("FORBIDDEN: You do not own this comic");
-  }
+  // Comic already belongs to this user — idempotent success
+  if (comic.userId === user.id) return { success: true };
 
-  if (comic.userId === user.id) {
-    return { success: true };
-  }
+  // Comic is owned by someone else
+  if (comic.userId !== null) throw new Error("FORBIDDEN: You do not own this comic");
 
   await claimComicInDb(id, user.id);
   return { success: true };

--- a/src/backend/handlers/claim-comic.ts
+++ b/src/backend/handlers/claim-comic.ts
@@ -1,0 +1,24 @@
+import { getComic, claimComic as claimComicInDb } from "@/backend/lib/db";
+import { getRequiredUser } from "@/backend/lib/supabase/middleware";
+
+interface ClaimComicResult {
+  success: boolean;
+}
+
+export async function claimComic(id: string): Promise<ClaimComicResult> {
+  const user = await getRequiredUser();
+
+  const comic = await getComic(id);
+  if (!comic) throw new Error("NOT_FOUND: Comic not found");
+
+  if (comic.userId !== null && comic.userId !== user.id) {
+    throw new Error("FORBIDDEN: You do not own this comic");
+  }
+
+  if (comic.userId === user.id) {
+    return { success: true };
+  }
+
+  await claimComicInDb(id, user.id);
+  return { success: true };
+}

--- a/src/backend/lib/db.ts
+++ b/src/backend/lib/db.ts
@@ -222,6 +222,15 @@ export async function deleteComic(id: string): Promise<void> {
   if (error) throw error;
 }
 
+export async function claimComic(id: string, userId: string): Promise<void> {
+  const { error } = await supabaseAdmin
+    .from("comics")
+    .update({ user_id: userId })
+    .eq("id", id)
+    .is("user_id", null);
+  if (error) throw error;
+}
+
 export async function getOrCreatePage(
   comicId: string,
   pageNumber: number

--- a/src/backend/lib/supabase/__tests__/middleware.test.ts
+++ b/src/backend/lib/supabase/__tests__/middleware.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const mockGetUser = vi.fn();
+const { mockGetUser } = vi.hoisted(() => ({ mockGetUser: vi.fn() }));
 
 vi.mock("../server", () => ({
   createRequestClient: vi.fn().mockResolvedValue({

--- a/src/frontend/lib/api.ts
+++ b/src/frontend/lib/api.ts
@@ -306,7 +306,6 @@ async function mockGetComic(id: string): Promise<{ comic: Comic }> {
   const isAutoComplete = _mockCompletedComics.has(id);
   const pageCount = 5;
 
-  // Collect pages generated in supervised mode
   const supervisedPages = Array.from({ length: pageCount }, (_, i) => {
     const versions = _mockPageVersions.get(`${id}-p${i + 1}`);
     return versions ?? null;
@@ -332,26 +331,6 @@ async function mockGetComic(id: string): Promise<{ comic: Comic }> {
         versions ? { pageNumber: i + 1, versions, selectedVersionIndex: versions.length - 1 } : null
       )
       .filter((p): p is Comic["pages"][number] => p !== null);
-  const pageCount = 5;
-
-  const allPagesSupervised = Array.from({ length: pageCount }, (_, i) =>
-    _mockPageVersions.has(`${id}-p${i + 1}`)
-  ).every(Boolean);
-
-  const isComplete = _mockCompletedComics.has(id) || allPagesSupervised;
-
-  let pages: Comic["pages"] = [];
-  if (_mockCompletedComics.has(id)) {
-    pages = Array.from({ length: pageCount }, (_, i) => ({
-      pageNumber: i + 1,
-      versions: [{ imageUrl: `https://picsum.photos/seed/${id}-p${i + 1}/800/1200`, generatedAt: new Date().toISOString() }],
-      selectedVersionIndex: 0,
-    }));
-  } else if (allPagesSupervised) {
-    pages = Array.from({ length: pageCount }, (_, i) => {
-      const versions = _mockPageVersions.get(`${id}-p${i + 1}`)!;
-      return { pageNumber: i + 1, versions, selectedVersionIndex: versions.length - 1 };
-    });
   }
 
   return {
@@ -371,7 +350,6 @@ async function mockGetComic(id: string): Promise<{ comic: Comic }> {
       ],
       pages,
       currentPageIndex: supervisedPageCount > 0 ? supervisedPageCount : (isComplete ? pageCount : 0),
-      currentPageIndex: isComplete ? pageCount : 0,
     },
   };
 }


### PR DESCRIPTION
## Summary

- Implements `PUT /api/comic/[id]/claim` to link a guest-created comic to an authenticated user's account
- Follows TDD red-green-refactor pattern with 3 clearly labelled commits
- Also fixes pre-existing corrupted `mockGetComic` in `api.ts`, malformed Swagger spec in `docs/route.ts`, and `vi.hoisted` bug in `middleware.test.ts`

## Endpoint behaviour

| Scenario | Response |
|----------|----------|
| Not logged in | 401 |
| Comic not found | 404 |
| Owned by another user | 403 |
| Already owned by current user | 200 (idempotent) |
| Guest comic (`userId = null`) | 200 — claims it |

## Files changed

- `src/backend/handlers/claim-comic.ts` — business logic handler
- `src/backend/lib/db.ts` — added `claimComic(id, userId)` query
- `src/app/api/comic/[id]/claim/route.ts` — PUT route
- `src/backend/handlers/__tests__/claim-comic.test.ts` — 5 unit tests (TDD)
- `src/app/api/docs/route.ts` — added endpoint to Swagger spec + fixed corrupted structure
- `src/frontend/lib/api.ts` — fixed corrupted `mockGetComic` duplicate code block
- `src/backend/lib/supabase/__tests__/middleware.test.ts` — fixed `vi.hoisted` hoisting bug

## Test plan

- [x] 184 tests pass (`npm run test -- --run`)
- [x] `npm run lint` passes with no errors
- [x] 5 dedicated tests cover all auth/ownership/idempotency scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)