### PR TITLE
test(frontend): add Playwright E2E test + fix malformed OpenAPI spec

### DIFF
--- a/e2e/comic-creation.spec.ts
+++ b/e2e/comic-creation.spec.ts
@@ -1,0 +1,214 @@
+import { test, expect } from "@playwright/test";
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const COMIC_ID = "e2e-test-comic-001";
+
+const MOCK_SCRIPT = {
+  title: "The Robot Painter",
+  synopsis: "A robot discovers the beauty of art in a grey world.",
+  pages: [
+    {
+      pageNumber: 1,
+      panels: [
+        {
+          panelNumber: 1,
+          description: "Wide shot of a grey factory floor.",
+          dialogue: [{ speaker: "Robot", text: "Is this all there is?" }],
+          caption: "Year 2087.",
+        },
+      ],
+    },
+    {
+      pageNumber: 2,
+      panels: [
+        {
+          panelNumber: 1,
+          description: "Robot discovers an abandoned art studio.",
+          dialogue: [],
+          caption: "A new beginning.",
+        },
+      ],
+    },
+  ],
+};
+
+const MOCK_FOLLOW_UP_QUESTIONS = [
+  { id: "q1", question: "What drives the robot to seek something more?" },
+];
+
+const MOCK_COMIC_INPUT = {
+  id: COMIC_ID,
+  userId: null,
+  status: "input" as const,
+  createdAt: "2026-04-19T00:00:00Z",
+  updatedAt: "2026-04-19T00:00:00Z",
+  prompt: "A robot learns to paint",
+  artStyle: "manga" as const,
+  pageCount: 2,
+  followUpQuestions: MOCK_FOLLOW_UP_QUESTIONS,
+  pages: [],
+  currentPageIndex: 0,
+};
+
+const MOCK_COMIC_COMPLETE = {
+  ...MOCK_COMIC_INPUT,
+  status: "complete" as const,
+  script: MOCK_SCRIPT,
+  generationMode: "automated" as const,
+  pages: [
+    {
+      pageNumber: 1,
+      versions: [
+        {
+          imageUrl: "https://example.com/page-1.png",
+          generatedAt: "2026-04-19T01:00:00Z",
+        },
+      ],
+      selectedVersionIndex: 0,
+    },
+    {
+      pageNumber: 2,
+      versions: [
+        {
+          imageUrl: "https://example.com/page-2.png",
+          generatedAt: "2026-04-19T01:00:00Z",
+        },
+      ],
+      selectedVersionIndex: 0,
+    },
+  ],
+  currentPageIndex: 2,
+};
+
+// ── Route setup ───────────────────────────────────────────────────────────────
+
+test.describe("Comic creation flow", () => {
+  test.beforeEach(async ({ page }) => {
+    // Track GET /api/comic/:id call count:
+    // - call 1: QA page mount → return input status with follow-up questions
+    // - call 2+: polling + comic viewer mount → return complete status
+    let getComicCallCount = 0;
+
+    // Register specific sub-routes before the generic /:id route so they match first.
+
+    await page.route("**/api/comic/random-idea", (route) =>
+      route.fulfill({ json: { idea: "A robot learns to paint in a grey world" } })
+    );
+
+    await page.route(`**/api/comic/${COMIC_ID}/script/generate`, (route) =>
+      route.fulfill({ json: { script: MOCK_SCRIPT } })
+    );
+
+    await page.route(`**/api/comic/${COMIC_ID}/refine`, (route) =>
+      route.fulfill({ json: { success: true } })
+    );
+
+    await page.route(`**/api/comic/${COMIC_ID}/approve`, (route) =>
+      route.fulfill({ json: { success: true } })
+    );
+
+    await page.route(`**/api/comic/${COMIC_ID}/generate-all`, (route) =>
+      route.fulfill({ json: { comic: MOCK_COMIC_COMPLETE } })
+    );
+
+    // GET /api/comic/:id — call-count-based response
+    await page.route(`**/api/comic/${COMIC_ID}`, (route) => {
+      if (route.request().method() !== "GET") {
+        route.continue();
+        return;
+      }
+      getComicCallCount++;
+      const comic = getComicCallCount === 1 ? MOCK_COMIC_INPUT : MOCK_COMIC_COMPLETE;
+      route.fulfill({ json: { comic } });
+    });
+
+    // POST /api/comic — create comic
+    await page.route("**/api/comic", (route) => {
+      if (route.request().method() !== "POST") {
+        route.continue();
+        return;
+      }
+      route.fulfill({
+        status: 201,
+        json: {
+          comicId: COMIC_ID,
+          followUpQuestions: MOCK_FOLLOW_UP_QUESTIONS,
+        },
+      });
+    });
+  });
+
+  // ── Happy path ──────────────────────────────────────────────────────────────
+
+  test("homepage → Q&A skip → script review → automated mode → comic viewer", async ({
+    page,
+  }) => {
+    // ── Step 1: Landing page ─────────────────────────────────────────────────
+    await page.goto("/");
+
+    // Fill the prompt textarea (id="prompt" per LandingPage.tsx)
+    await page.fill("#prompt", "A robot learns to paint in a grey world");
+
+    // Default art style is "manga" — no change needed.
+    // Default page count is 5 — no change needed.
+
+    // Submit the form
+    await page.getByRole("button", { name: "Create Comic" }).click();
+
+    // ── Step 2: Q&A page ─────────────────────────────────────────────────────
+    await page.waitForURL(`**/create?id=${COMIC_ID}`);
+
+    // Wait for the question to load (QA page fetches comic on mount)
+    await expect(
+      page.getByText(MOCK_FOLLOW_UP_QUESTIONS[0].question)
+    ).toBeVisible();
+
+    // Skip all questions
+    await page.getByRole("button", { name: "Skip All" }).click();
+
+    // ── Step 3: Script review page ────────────────────────────────────────────
+    await page.waitForURL(`**/script/${COMIC_ID}`);
+
+    // Wait for script generation to complete (script title appears as <h1>)
+    await expect(
+      page.getByRole("heading", { name: MOCK_SCRIPT.title })
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Select Automated mode (role="radio" aria-label="Automated mode" per ScriptReviewPage.tsx)
+    await page.getByRole("radio", { name: "Automated mode" }).click();
+
+    // Install fake clock NOW so the polling setInterval (created after approve)
+    // uses the fake clock and can be triggered instantly with clock.tick().
+    await page.clock.install();
+
+    // Click Approve & Generate (button text changes to this when automated is selected)
+    await page.getByRole("button", { name: "Approve & Generate" }).click();
+
+    // Polling phase starts — progress banner should appear
+    // (role="status" aria-label="Generation progress" per ScriptReviewPage.tsx)
+    await expect(
+      page.getByRole("status", { name: "Generation progress" })
+    ).toBeVisible();
+
+    // Advance the fake clock past the 5 000 ms polling interval to trigger the
+    // first poll. The mock returns status:"complete", which navigates to viewer.
+    // runFor fires all callbacks along the way (unlike fastForward which skips them).
+    await page.clock.runFor(5_100);
+
+    // ── Step 4: Comic viewer ──────────────────────────────────────────────────
+    await page.waitForURL(`**/comic/${COMIC_ID}`, { timeout: 10_000 });
+
+    // Title heading (comic?.script?.title per ComicViewerPage.tsx)
+    await expect(
+      page.getByRole("heading", { name: MOCK_SCRIPT.title })
+    ).toBeVisible();
+
+    // Comic pages rendered as <img alt="Page N">
+    await expect(page.getByAltText("Page 1")).toBeVisible();
+    await expect(page.getByAltText("Page 2")).toBeVisible();
+
+    // Share button present for all viewers
+    await expect(page.getByRole("button", { name: "Share" })).toBeVisible();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@supabase/ssr": "^0.10.2",
         "@supabase/supabase-js": "^2.103.3",
         "jspdf": "^4.2.1",
-        "next": "16.2.2",
+        "next": "^16.2.4",
         "pdf-lib": "^1.17.1",
         "react": "19.2.4",
         "react-dom": "19.2.4",
@@ -1428,9 +1428,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.2.tgz",
-      "integrity": "sha512-LqSGz5+xGk9EL/iBDr2yo/CgNQV6cFsNhRR2xhSXYh7B/hb4nePCxlmDvGEKG30NMHDFf0raqSyOZiQrO7BkHQ==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.4.tgz",
+      "integrity": "sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -1444,9 +1444,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.2.tgz",
-      "integrity": "sha512-B92G3ulrwmkDSEJEp9+XzGLex5wC1knrmCSIylyVeiAtCIfvEJYiN3v5kXPlYt5R4RFlsfO/v++aKV63Acrugg==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.4.tgz",
+      "integrity": "sha512-OXTFFox5EKN1Ym08vfrz+OXxmCcEjT4SFMbNRsWZE99dMqt2Kcusl5MqPXcW232RYkMLQTy0hqgAMEsfEd/l2A==",
       "cpu": [
         "arm64"
       ],
@@ -1460,9 +1460,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.2.tgz",
-      "integrity": "sha512-7ZwSgNKJNQiwW0CKhNm9B1WS2L1Olc4B2XY0hPYCAL3epFnugMhuw5TMWzMilQ3QCZcCHoYm9NGWTHbr5REFxw==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.4.tgz",
+      "integrity": "sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ==",
       "cpu": [
         "x64"
       ],
@@ -1476,9 +1476,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.2.tgz",
-      "integrity": "sha512-c3m8kBHMziMgo2fICOP/cd/5YlrxDU5YYjAJeQLyFsCqVF8xjOTH/QYG4a2u48CvvZZSj1eHQfBCbyh7kBr30Q==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.4.tgz",
+      "integrity": "sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ==",
       "cpu": [
         "arm64"
       ],
@@ -1492,9 +1492,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.2.tgz",
-      "integrity": "sha512-VKLuscm0P/mIfzt+SDdn2+8TNNJ7f0qfEkA+az7OqQbjzKdBxAHs0UvuiVoCtbwX+dqMEL9U54b5wQ/aN3dHeg==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.4.tgz",
+      "integrity": "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==",
       "cpu": [
         "arm64"
       ],
@@ -1508,9 +1508,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.2.tgz",
-      "integrity": "sha512-kU3OPHJq6sBUjOk7wc5zJ7/lipn8yGldMoAv4z67j6ov6Xo/JvzA7L7LCsyzzsXmgLEhk3Qkpwqaq/1+XpNR3g==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.4.tgz",
+      "integrity": "sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==",
       "cpu": [
         "x64"
       ],
@@ -1524,9 +1524,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.2.tgz",
-      "integrity": "sha512-CKXRILyErMtUftp+coGcZ38ZwE/Aqq45VMCcRLr2I4OXKrgxIBDXHnBgeX/UMil0S09i2JXaDL3Q+TN8D/cKmg==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.4.tgz",
+      "integrity": "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==",
       "cpu": [
         "x64"
       ],
@@ -1540,9 +1540,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.2.tgz",
-      "integrity": "sha512-sS/jSk5VUoShUqINJFvNjVT7JfR5ORYj/+/ZpOYbbIohv/lQfduWnGAycq2wlknbOql2xOR0DoV0s6Xfcy49+g==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.4.tgz",
+      "integrity": "sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==",
       "cpu": [
         "arm64"
       ],
@@ -1556,9 +1556,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.2.tgz",
-      "integrity": "sha512-aHaKceJgdySReT7qeck5oShucxWRiiEuwCGK8HHALe6yZga8uyFpLkPgaRw3kkF04U7ROogL/suYCNt/+CuXGA==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.4.tgz",
+      "integrity": "sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw==",
       "cpu": [
         "x64"
       ],
@@ -8252,12 +8252,12 @@
       }
     },
     "node_modules/next": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.2.tgz",
-      "integrity": "sha512-i6AJdyVa4oQjyvX/6GeER8dpY/xlIV+4NMv/svykcLtURJSy/WzDnnUk/TM4d0uewFHK7xSQz4TbIwPgjky+3A==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.4.tgz",
+      "integrity": "sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.2",
+        "@next/env": "16.2.4",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -8271,14 +8271,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.2",
-        "@next/swc-darwin-x64": "16.2.2",
-        "@next/swc-linux-arm64-gnu": "16.2.2",
-        "@next/swc-linux-arm64-musl": "16.2.2",
-        "@next/swc-linux-x64-gnu": "16.2.2",
-        "@next/swc-linux-x64-musl": "16.2.2",
-        "@next/swc-win32-arm64-msvc": "16.2.2",
-        "@next/swc-win32-x64-msvc": "16.2.2",
+        "@next/swc-darwin-arm64": "16.2.4",
+        "@next/swc-darwin-x64": "16.2.4",
+        "@next/swc-linux-arm64-gnu": "16.2.4",
+        "@next/swc-linux-arm64-musl": "16.2.4",
+        "@next/swc-linux-x64-gnu": "16.2.4",
+        "@next/swc-linux-x64-musl": "16.2.4",
+        "@next/swc-win32-arm64-msvc": "16.2.4",
+        "@next/swc-win32-x64-msvc": "16.2.4",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "swagger-ui-react": "^5.32.4"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -1662,6 +1663,12 @@
         "pako": "^1.0.6"
       }
     },
+    "node_modules/@pdf-lib/standard-fonts/node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/@pdf-lib/upng": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz",
@@ -1669,6 +1676,28 @@
       "license": "MIT",
       "dependencies": {
         "pako": "^1.0.10"
+      }
+    },
+    "node_modules/@pdf-lib/upng/node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -8661,9 +8690,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
       "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
       "license": "(MIT AND Zlib)"
     },
     "node_modules/parent-module": {
@@ -8758,12 +8784,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-      "license": "MIT",
-      "optional": true
     "node_modules/pdf-lib": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
@@ -8776,11 +8796,24 @@
         "tslib": "^1.11.1"
       }
     },
+    "node_modules/pdf-lib/node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/pdf-lib/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -8799,6 +8832,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "eslint",
     "test": "vitest run",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@google/genai": "^1.50.1",
@@ -22,6 +23,7 @@
     "swagger-ui-react": "^5.32.4"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@supabase/ssr": "^0.10.2",
     "@supabase/supabase-js": "^2.103.3",
     "jspdf": "^4.2.1",
-    "next": "16.2.2",
+    "next": "^16.2.4",
     "pdf-lib": "^1.17.1",
     "react": "19.2.4",
     "react-dom": "19.2.4",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: [["html", { open: "never" }]],
+  use: {
+    baseURL: "http://localhost:3000",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "npm run dev",
+    url: "http://localhost:3000",
+    reuseExistingServer: !process.env.CI,
+    env: {
+      // Disable mock API so page.route() can intercept real fetch calls
+      NEXT_PUBLIC_USE_MOCK_API: "false",
+      // Dummy Supabase values so createBrowserClient doesn't throw;
+      // getUser() returns null (no session) without making HTTP requests.
+      NEXT_PUBLIC_SUPABASE_URL: "http://localhost:54321",
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: "e2e-dummy-anon-key",
+      NEXT_PUBLIC_BASE_URL: "http://localhost:3000",
+    },
+  },
+});

--- a/src/app/api/docs/route.ts
+++ b/src/app/api/docs/route.ts
@@ -196,6 +196,11 @@ const spec = {
         responses: {
           "200": { description: "PDF file", content: { "application/pdf": { schema: { type: "string", format: "binary" } } } },
           "400": { description: "Comic is not complete" },
+          "404": { description: "Comic not found" },
+          "500": { description: "Internal server error" },
+        },
+      },
+    },
     "/api/library": {
       get: {
         summary: "Get user library",
@@ -217,6 +222,10 @@ const spec = {
             },
           },
           "401": { description: "Authentication required" },
+          "500": { description: "Internal server error" },
+        },
+      },
+    },
     "/api/comic/{id}/page/generate": {
       post: {
         summary: "Generate page image",
@@ -253,6 +262,24 @@ const spec = {
         parameters: [{ name: "id", in: "path", required: true, schema: { type: "string", format: "uuid" } }],
         responses: {
           "200": { description: "Comic object", content: { "application/json": { schema: { type: "object", properties: { comic: { type: "object" } } } } } },
+          "404": { description: "Comic not found" },
+          "500": { description: "Internal server error" },
+        },
+      },
+      delete: {
+        summary: "Delete comic",
+        description: "Deletes a comic and all its associated storage images. Requires authentication and ownership.",
+        tags: ["Library"],
+        security: [{ bearerAuth: [] }],
+        parameters: [{ name: "id", in: "path", required: true, schema: { type: "string", format: "uuid" } }],
+        responses: {
+          "200": { description: "Comic deleted", content: { "application/json": { schema: { type: "object", properties: { success: { type: "boolean" } } } } } },
+          "401": { description: "Authentication required" },
+          "403": { description: "Not the comic owner" },
+          "500": { description: "Internal server error" },
+        },
+      },
+    },
     "/api/comic/{id}/page/regenerate": {
       post: {
         summary: "Regenerate page image",
@@ -281,16 +308,6 @@ const spec = {
           "500": { description: "Internal server error" },
         },
       },
-      delete: {
-        summary: "Delete comic",
-        description: "Deletes a comic and all its associated storage images. Requires authentication and ownership.",
-        tags: ["Library"],
-        security: [{ bearerAuth: [] }],
-        parameters: [{ name: "id", in: "path", required: true, schema: { type: "string", format: "uuid" } }],
-        responses: {
-          "200": { description: "Comic deleted", content: { "application/json": { schema: { type: "object", properties: { success: { type: "boolean" } } } } } },
-          "401": { description: "Authentication required" },
-          "403": { description: "Not the comic owner" },
     },
     "/api/comic/{id}/page/select": {
       put: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     environment: "jsdom",
     setupFiles: ["./vitest.setup.ts"],
     globals: true,
+    exclude: ["**/node_modules/**", "**/e2e/**"],
     coverage: {
       provider: "v8",
       include: [


### PR DESCRIPTION
## Summary

- Added Playwright E2E test covering the full comic creation flow (landing → Q&A → script review → comic viewer)
- Fixed malformed OpenAPI spec in `src/app/api/docs/route.ts` — three path entries (`/export/pdf`, `/api/library`, `/api/comic/{id}`) had missing closing braces causing cascading TS/lint parse errors; `delete` operation was incorrectly nested inside `/page/regenerate` instead of `/{id}`
- Bumped `next` from `16.2.2` to `^16.2.4` (patch)

## Test plan

- [x] `npm run test:coverage` — 206 tests pass, 81–85% coverage (above 70% threshold)
- [x] `npm run lint` — 0 errors
- [x] `npx tsc --noEmit` — 0 errors
- [x] Playwright E2E test added for comic creation flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)