### PR TITLE
feat(backend): add Zod input validation for all API routes (#32)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "pdf-lib": "^1.17.1",
         "react": "19.2.4",
         "react-dom": "19.2.4",
-        "swagger-ui-react": "^5.32.4"
+        "swagger-ui-react": "^5.32.4",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@playwright/test": "^1.59.1",
@@ -10071,7 +10072,6 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "pdf-lib": "^1.17.1",
     "react": "19.2.4",
     "react-dom": "19.2.4",
-    "swagger-ui-react": "^5.32.4"
+    "swagger-ui-react": "^5.32.4",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",

--- a/src/backend/handlers/approve-comic.ts
+++ b/src/backend/handlers/approve-comic.ts
@@ -1,4 +1,3 @@
-import type { Script } from "@/backend/lib/types";
 import { getComic, saveComic } from "@/backend/lib/db";
 import { validateScript } from "@/backend/lib/ai/script-generator";
 import { parseOrThrow, ApproveComicSchema } from "@/backend/lib/validation";
@@ -11,8 +10,7 @@ export async function approveComic(
   id: string,
   body: unknown
 ): Promise<ApproveComicResult> {
-  const raw = parseOrThrow(ApproveComicSchema, body);
-  const input = { script: raw.script as unknown as Script, generationMode: raw.generationMode };
+  const input = parseOrThrow(ApproveComicSchema, body);
 
   const comic = await getComic(id);
   if (!comic) throw new Error("NOT_FOUND: Comic not found");

--- a/src/backend/handlers/approve-comic.ts
+++ b/src/backend/handlers/approve-comic.ts
@@ -1,42 +1,18 @@
-import type { Script, GenerationMode } from "@/backend/lib/types";
+import type { Script } from "@/backend/lib/types";
 import { getComic, saveComic } from "@/backend/lib/db";
 import { validateScript } from "@/backend/lib/ai/script-generator";
-
-interface ApproveComicInput {
-  script: Script;
-  generationMode: GenerationMode;
-}
+import { parseOrThrow, ApproveComicSchema } from "@/backend/lib/validation";
 
 interface ApproveComicResult {
   success: true;
-}
-
-const VALID_MODES: GenerationMode[] = ["supervised", "automated"];
-
-function validate(body: unknown): ApproveComicInput {
-  if (!body || typeof body !== "object") {
-    throw new Error("INVALID_INPUT: Request body is required");
-  }
-  const { script, generationMode } = body as Record<string, unknown>;
-
-  if (!script || typeof script !== "object") {
-    throw new Error("INVALID_INPUT: script is required");
-  }
-  if (!generationMode || !VALID_MODES.includes(generationMode as GenerationMode)) {
-    throw new Error("INVALID_INPUT: generationMode must be 'supervised' or 'automated'");
-  }
-
-  return {
-    script: script as Script,
-    generationMode: generationMode as GenerationMode,
-  };
 }
 
 export async function approveComic(
   id: string,
   body: unknown
 ): Promise<ApproveComicResult> {
-  const input = validate(body);
+  const raw = parseOrThrow(ApproveComicSchema, body);
+  const input = { script: raw.script as unknown as Script, generationMode: raw.generationMode };
 
   const comic = await getComic(id);
   if (!comic) throw new Error("NOT_FOUND: Comic not found");

--- a/src/backend/handlers/create-comic.ts
+++ b/src/backend/handlers/create-comic.ts
@@ -1,72 +1,16 @@
-import type { ArtStylePreset, FollowUpQuestion } from "@/backend/lib/types";
-import { MIN_PAGES, MAX_PAGES } from "@/backend/lib/constants";
+import type { FollowUpQuestion } from "@/backend/lib/types";
 import { getOptionalUser } from "@/backend/lib/supabase/middleware";
 import { generateFollowUpQuestions } from "@/backend/lib/ai/script-generator";
 import { insertComic } from "@/backend/lib/db";
-
-const VALID_ART_STYLES: ArtStylePreset[] = [
-  "manga",
-  "western_comic",
-  "watercolor_storybook",
-  "minimalist_flat",
-  "vintage_newspaper",
-  "custom",
-];
-
-interface CreateComicInput {
-  prompt: string;
-  artStyle: ArtStylePreset;
-  customStylePrompt?: string | null;
-  pageCount: number;
-}
+import { parseOrThrow, CreateComicSchema } from "@/backend/lib/validation";
 
 interface CreateComicResult {
   comicId: string;
   followUpQuestions: FollowUpQuestion[];
 }
 
-function validate(body: unknown): CreateComicInput {
-  if (!body || typeof body !== "object") {
-    throw new Error("INVALID_INPUT: Request body is required");
-  }
-
-  const { prompt, artStyle, customStylePrompt, pageCount } = body as Record<string, unknown>;
-
-  if (!prompt || typeof prompt !== "string" || prompt.trim() === "") {
-    throw new Error("INVALID_INPUT: prompt is required and must be a non-empty string");
-  }
-
-  if (!artStyle || !VALID_ART_STYLES.includes(artStyle as ArtStylePreset)) {
-    throw new Error(
-      `INVALID_INPUT: artStyle must be one of: ${VALID_ART_STYLES.join(", ")}`
-    );
-  }
-
-  if (artStyle === "custom" && (!customStylePrompt || typeof customStylePrompt !== "string" || customStylePrompt.trim() === "")) {
-    throw new Error("INVALID_INPUT: customStylePrompt is required when artStyle is 'custom'");
-  }
-
-  if (
-    typeof pageCount !== "number" ||
-    !Number.isInteger(pageCount) ||
-    pageCount < MIN_PAGES ||
-    pageCount > MAX_PAGES
-  ) {
-    throw new Error(
-      `INVALID_INPUT: pageCount must be an integer between ${MIN_PAGES} and ${MAX_PAGES}`
-    );
-  }
-
-  return {
-    prompt: prompt.trim(),
-    artStyle: artStyle as ArtStylePreset,
-    customStylePrompt: typeof customStylePrompt === "string" ? customStylePrompt : undefined,
-    pageCount,
-  };
-}
-
 export async function createComic(body: unknown): Promise<CreateComicResult> {
-  const input = validate(body);
+  const input = parseOrThrow(CreateComicSchema, body);
 
   const user = await getOptionalUser();
 

--- a/src/backend/handlers/generate-page.ts
+++ b/src/backend/handlers/generate-page.ts
@@ -3,20 +3,10 @@ import { getComic, saveComic, getOrCreatePage, addPageVersion } from "@/backend/
 import { uploadImage, uploadCharacterSheet } from "@/backend/lib/supabase/storage";
 import { buildCharacterSheetPrompt, buildPageImagePrompt } from "@/backend/lib/ai/prompts";
 import { generatePageImage, generateCharacterSheet } from "@/backend/lib/ai/image-generator";
+import { parseOrThrow, PageGenerateSchema } from "@/backend/lib/validation";
 
 interface GeneratePageResult {
   page: Page;
-}
-
-function validateBody(body: unknown): { pageNumber: number } {
-  if (!body || typeof body !== "object") {
-    throw new Error("INVALID_INPUT: Request body is required");
-  }
-  const { pageNumber } = body as Record<string, unknown>;
-  if (typeof pageNumber !== "number" || !Number.isInteger(pageNumber) || pageNumber < 1) {
-    throw new Error("INVALID_INPUT: pageNumber must be a positive integer");
-  }
-  return { pageNumber };
 }
 
 async function fetchBuffer(url: string): Promise<Buffer> {
@@ -26,7 +16,7 @@ async function fetchBuffer(url: string): Promise<Buffer> {
 }
 
 export async function generatePage(id: string, body: unknown): Promise<GeneratePageResult> {
-  const { pageNumber } = validateBody(body);
+  const { pageNumber } = parseOrThrow(PageGenerateSchema, body);
 
   const comic = await getComic(id);
   if (!comic) throw new Error("NOT_FOUND: Comic not found");

--- a/src/backend/handlers/refine-comic.ts
+++ b/src/backend/handlers/refine-comic.ts
@@ -1,34 +1,15 @@
 import { getComic, saveComic } from "@/backend/lib/db";
-
-interface RefineComicInput {
-  answers: Record<string, string>;
-}
+import { parseOrThrow, RefineComicSchema } from "@/backend/lib/validation";
 
 interface RefineComicResult {
   success: true;
-}
-
-function validate(body: unknown): RefineComicInput {
-  if (!body || typeof body !== "object") {
-    throw new Error("INVALID_INPUT: Request body is required");
-  }
-  const { answers } = body as Record<string, unknown>;
-  if (!answers || typeof answers !== "object" || Array.isArray(answers)) {
-    throw new Error("INVALID_INPUT: answers must be an object");
-  }
-  for (const [key, val] of Object.entries(answers)) {
-    if (typeof val !== "string") {
-      throw new Error(`INVALID_INPUT: answer for ${key} must be a string`);
-    }
-  }
-  return { answers: answers as Record<string, string> };
 }
 
 export async function refineComic(
   id: string,
   body: unknown
 ): Promise<RefineComicResult> {
-  const input = validate(body);
+  const input = parseOrThrow(RefineComicSchema, body);
 
   const comic = await getComic(id);
   if (!comic) throw new Error("NOT_FOUND: Comic not found");

--- a/src/backend/handlers/regenerate-page.ts
+++ b/src/backend/handlers/regenerate-page.ts
@@ -3,31 +3,12 @@ import { getComic, getOrCreatePage, addPageVersion, selectPageVersion } from "@/
 import { uploadImage } from "@/backend/lib/supabase/storage";
 import { buildPageImagePrompt } from "@/backend/lib/ai/prompts";
 import { generatePageImage } from "@/backend/lib/ai/image-generator";
+import { parseOrThrow, PageRegenerateSchema } from "@/backend/lib/validation";
 
 const MAX_VERSIONS = 4;
 
 interface RegeneratePageResult {
   page: Page;
-}
-
-interface ValidatedBody {
-  pageNumber: number;
-  feedback?: string;
-}
-
-function validateBody(body: unknown): ValidatedBody {
-  if (!body || typeof body !== "object") {
-    throw new Error("INVALID_INPUT: Request body is required");
-  }
-  const { pageNumber, feedback } = body as Record<string, unknown>;
-  if (typeof pageNumber !== "number" || !Number.isInteger(pageNumber) || pageNumber < 1) {
-    throw new Error("INVALID_INPUT: pageNumber must be a positive integer");
-  }
-  if (feedback !== undefined && typeof feedback !== "string") {
-    throw new Error("INVALID_INPUT: feedback must be a string");
-  }
-  const trimmed = typeof feedback === "string" ? feedback.trim() : undefined;
-  return { pageNumber, feedback: trimmed || undefined };
 }
 
 async function fetchBuffer(url: string): Promise<Buffer> {
@@ -40,7 +21,9 @@ export async function regeneratePage(
   id: string,
   body: unknown
 ): Promise<RegeneratePageResult> {
-  const { pageNumber, feedback } = validateBody(body);
+  const parsed = parseOrThrow(PageRegenerateSchema, body);
+  const pageNumber = parsed.pageNumber;
+  const feedback = typeof parsed.feedback === "string" ? parsed.feedback.trim() || undefined : undefined;
 
   const comic = await getComic(id);
   if (!comic) throw new Error("NOT_FOUND: Comic not found");

--- a/src/backend/handlers/regenerate-script.ts
+++ b/src/backend/handlers/regenerate-script.ts
@@ -1,36 +1,18 @@
 import type { Script } from "@/backend/lib/types";
 import { getComic, saveComic } from "@/backend/lib/db";
 import { regenerateScript as regenerateScriptAI } from "@/backend/lib/ai/script-generator";
-
-const MAX_FEEDBACK_LENGTH = 2000;
+import { parseOrThrow, RegenerateScriptSchema } from "@/backend/lib/validation";
 
 interface RegenerateScriptResult {
   script: Script;
-}
-
-function validate(body: unknown): { feedback: string } {
-  if (!body || typeof body !== "object") {
-    throw new Error("INVALID_INPUT: Request body is required");
-  }
-
-  const { feedback } = body as Record<string, unknown>;
-
-  if (!feedback || typeof feedback !== "string" || feedback.trim() === "") {
-    throw new Error("INVALID_INPUT: feedback is required and must be a non-empty string");
-  }
-
-  if (feedback.length > MAX_FEEDBACK_LENGTH) {
-    throw new Error(`INVALID_INPUT: feedback must not exceed ${MAX_FEEDBACK_LENGTH} characters`);
-  }
-
-  return { feedback: feedback.trim() };
 }
 
 export async function regenerateComicScript(
   id: string,
   body: unknown
 ): Promise<RegenerateScriptResult> {
-  const { feedback } = validate(body);
+  const parsed = parseOrThrow(RegenerateScriptSchema, body);
+  const feedback = parsed.feedback.trim();
 
   const comic = await getComic(id);
   if (!comic) throw new Error("NOT_FOUND: Comic not found");

--- a/src/backend/handlers/select-page.ts
+++ b/src/backend/handlers/select-page.ts
@@ -1,26 +1,13 @@
 import { getComic, saveComic, selectPageVersion } from "@/backend/lib/db";
+import { parseOrThrow, PageSelectSchema } from "@/backend/lib/validation";
 
 interface SelectPageResult {
   success: boolean;
   complete: boolean;
 }
 
-function validateBody(body: unknown): { pageNumber: number; versionIndex: number } {
-  if (!body || typeof body !== "object") {
-    throw new Error("INVALID_INPUT: Request body is required");
-  }
-  const { pageNumber, versionIndex } = body as Record<string, unknown>;
-  if (typeof pageNumber !== "number" || !Number.isInteger(pageNumber) || pageNumber < 1) {
-    throw new Error("INVALID_INPUT: pageNumber must be a positive integer");
-  }
-  if (typeof versionIndex !== "number" || !Number.isInteger(versionIndex) || versionIndex < 0) {
-    throw new Error("INVALID_INPUT: versionIndex must be a non-negative integer");
-  }
-  return { pageNumber, versionIndex };
-}
-
 export async function selectPage(id: string, body: unknown): Promise<SelectPageResult> {
-  const { pageNumber, versionIndex } = validateBody(body);
+  const { pageNumber, versionIndex } = parseOrThrow(PageSelectSchema, body);
 
   const comic = await getComic(id);
   if (!comic) throw new Error("NOT_FOUND: Comic not found");

--- a/src/backend/lib/__tests__/validation.test.ts
+++ b/src/backend/lib/__tests__/validation.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseOrThrow,
+  CreateComicSchema,
+  RefineComicSchema,
+  RegenerateScriptSchema,
+  ApproveComicSchema,
+  PageGenerateSchema,
+  PageRegenerateSchema,
+  PageSelectSchema,
+} from "../validation";
+
+function expectInvalidInput(fn: () => unknown, fragment: string) {
+  expect(fn).toThrow(expect.objectContaining({ message: expect.stringContaining("INVALID_INPUT:") }));
+  expect(fn).toThrow(expect.objectContaining({ message: expect.stringContaining(fragment) }));
+}
+
+// ---------------------------------------------------------------------------
+// CreateComicSchema
+// ---------------------------------------------------------------------------
+
+describe("CreateComicSchema", () => {
+  const valid = { prompt: "A cat detective", artStyle: "manga", pageCount: 5 };
+
+  it("accepts valid input", () => {
+    expect(parseOrThrow(CreateComicSchema, valid)).toMatchObject(valid);
+  });
+
+  it("accepts custom art style with customStylePrompt", () => {
+    const input = { ...valid, artStyle: "custom", customStylePrompt: "noir pencil sketches" };
+    expect(() => parseOrThrow(CreateComicSchema, input)).not.toThrow();
+  });
+
+  it("rejects missing prompt", () => {
+    expectInvalidInput(() => parseOrThrow(CreateComicSchema, { ...valid, prompt: undefined }), "prompt");
+  });
+
+  it("rejects empty prompt", () => {
+    expectInvalidInput(() => parseOrThrow(CreateComicSchema, { ...valid, prompt: "" }), "prompt");
+  });
+
+  it("rejects invalid artStyle", () => {
+    expectInvalidInput(() => parseOrThrow(CreateComicSchema, { ...valid, artStyle: "oil_painting" }), "artStyle");
+  });
+
+  it("rejects custom artStyle without customStylePrompt", () => {
+    expectInvalidInput(
+      () => parseOrThrow(CreateComicSchema, { ...valid, artStyle: "custom" }),
+      "customStylePrompt"
+    );
+  });
+
+  it("rejects custom artStyle with empty customStylePrompt", () => {
+    expectInvalidInput(
+      () => parseOrThrow(CreateComicSchema, { ...valid, artStyle: "custom", customStylePrompt: "   " }),
+      "customStylePrompt"
+    );
+  });
+
+  it("rejects pageCount below minimum", () => {
+    expectInvalidInput(() => parseOrThrow(CreateComicSchema, { ...valid, pageCount: 0 }), "pageCount");
+  });
+
+  it("rejects pageCount above maximum", () => {
+    expectInvalidInput(() => parseOrThrow(CreateComicSchema, { ...valid, pageCount: 16 }), "pageCount");
+  });
+
+  it("rejects non-integer pageCount", () => {
+    expectInvalidInput(() => parseOrThrow(CreateComicSchema, { ...valid, pageCount: 3.5 }), "pageCount");
+  });
+
+  it("rejects missing fields", () => {
+    expectInvalidInput(() => parseOrThrow(CreateComicSchema, {}), "prompt");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RefineComicSchema
+// ---------------------------------------------------------------------------
+
+describe("RefineComicSchema", () => {
+  it("accepts valid answers object", () => {
+    const input = { answers: { q1: "Inspector Whiskers", q2: "diamond heist" } };
+    expect(parseOrThrow(RefineComicSchema, input)).toEqual(input);
+  });
+
+  it("accepts empty answers object", () => {
+    expect(() => parseOrThrow(RefineComicSchema, { answers: {} })).not.toThrow();
+  });
+
+  it("rejects missing answers", () => {
+    expectInvalidInput(() => parseOrThrow(RefineComicSchema, {}), "answers");
+  });
+
+  it("rejects answers as an array", () => {
+    expectInvalidInput(() => parseOrThrow(RefineComicSchema, { answers: ["q1"] }), "answers");
+  });
+
+  it("rejects answers with non-string values", () => {
+    expectInvalidInput(() => parseOrThrow(RefineComicSchema, { answers: { q1: 42 } }), "answers");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RegenerateScriptSchema
+// ---------------------------------------------------------------------------
+
+describe("RegenerateScriptSchema", () => {
+  it("accepts valid feedback", () => {
+    expect(parseOrThrow(RegenerateScriptSchema, { feedback: "Make the villain sympathetic" })).toEqual({
+      feedback: "Make the villain sympathetic",
+    });
+  });
+
+  it("rejects missing feedback", () => {
+    expectInvalidInput(() => parseOrThrow(RegenerateScriptSchema, {}), "feedback");
+  });
+
+  it("rejects empty feedback", () => {
+    expectInvalidInput(() => parseOrThrow(RegenerateScriptSchema, { feedback: "" }), "feedback");
+  });
+
+  it("rejects feedback over 2000 characters", () => {
+    expectInvalidInput(
+      () => parseOrThrow(RegenerateScriptSchema, { feedback: "x".repeat(2001) }),
+      "feedback"
+    );
+  });
+
+  it("rejects non-string feedback", () => {
+    expectInvalidInput(() => parseOrThrow(RegenerateScriptSchema, { feedback: 123 }), "feedback");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ApproveComicSchema
+// ---------------------------------------------------------------------------
+
+describe("ApproveComicSchema", () => {
+  const script = { title: "Test", synopsis: "A story", characters: [], pages: [] };
+
+  it("accepts supervised mode", () => {
+    const result = parseOrThrow(ApproveComicSchema, { script, generationMode: "supervised" });
+    expect(result.generationMode).toBe("supervised");
+  });
+
+  it("accepts automated mode", () => {
+    const result = parseOrThrow(ApproveComicSchema, { script, generationMode: "automated" });
+    expect(result.generationMode).toBe("automated");
+  });
+
+  it("rejects missing script", () => {
+    expectInvalidInput(() => parseOrThrow(ApproveComicSchema, { generationMode: "automated" }), "script");
+  });
+
+  it("rejects script as a string", () => {
+    expectInvalidInput(() => parseOrThrow(ApproveComicSchema, { script: "not an object", generationMode: "automated" }), "script");
+  });
+
+  it("rejects invalid generationMode", () => {
+    expectInvalidInput(() => parseOrThrow(ApproveComicSchema, { script, generationMode: "batch" }), "generationMode");
+  });
+
+  it("rejects missing generationMode", () => {
+    expectInvalidInput(() => parseOrThrow(ApproveComicSchema, { script }), "generationMode");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PageGenerateSchema
+// ---------------------------------------------------------------------------
+
+describe("PageGenerateSchema", () => {
+  it("accepts a valid pageNumber", () => {
+    expect(parseOrThrow(PageGenerateSchema, { pageNumber: 1 })).toEqual({ pageNumber: 1 });
+  });
+
+  it("rejects missing pageNumber", () => {
+    expectInvalidInput(() => parseOrThrow(PageGenerateSchema, {}), "pageNumber");
+  });
+
+  it("rejects pageNumber of 0", () => {
+    expectInvalidInput(() => parseOrThrow(PageGenerateSchema, { pageNumber: 0 }), "pageNumber");
+  });
+
+  it("rejects negative pageNumber", () => {
+    expectInvalidInput(() => parseOrThrow(PageGenerateSchema, { pageNumber: -1 }), "pageNumber");
+  });
+
+  it("rejects non-integer pageNumber", () => {
+    expectInvalidInput(() => parseOrThrow(PageGenerateSchema, { pageNumber: 1.5 }), "pageNumber");
+  });
+
+  it("rejects string pageNumber", () => {
+    expectInvalidInput(() => parseOrThrow(PageGenerateSchema, { pageNumber: "1" }), "pageNumber");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PageRegenerateSchema
+// ---------------------------------------------------------------------------
+
+describe("PageRegenerateSchema", () => {
+  it("accepts pageNumber without feedback", () => {
+    expect(parseOrThrow(PageRegenerateSchema, { pageNumber: 2 })).toMatchObject({ pageNumber: 2 });
+  });
+
+  it("accepts pageNumber with feedback", () => {
+    const result = parseOrThrow(PageRegenerateSchema, { pageNumber: 2, feedback: "Warmer colours" });
+    expect(result).toMatchObject({ pageNumber: 2, feedback: "Warmer colours" });
+  });
+
+  it("rejects missing pageNumber", () => {
+    expectInvalidInput(() => parseOrThrow(PageRegenerateSchema, {}), "pageNumber");
+  });
+
+  it("rejects pageNumber below 1", () => {
+    expectInvalidInput(() => parseOrThrow(PageRegenerateSchema, { pageNumber: 0 }), "pageNumber");
+  });
+
+  it("rejects feedback over 2000 characters", () => {
+    expectInvalidInput(
+      () => parseOrThrow(PageRegenerateSchema, { pageNumber: 1, feedback: "x".repeat(2001) }),
+      "feedback"
+    );
+  });
+
+  it("rejects non-string feedback", () => {
+    expectInvalidInput(() => parseOrThrow(PageRegenerateSchema, { pageNumber: 1, feedback: 99 }), "feedback");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PageSelectSchema
+// ---------------------------------------------------------------------------
+
+describe("PageSelectSchema", () => {
+  it("accepts valid pageNumber and versionIndex", () => {
+    expect(parseOrThrow(PageSelectSchema, { pageNumber: 3, versionIndex: 0 })).toEqual({
+      pageNumber: 3,
+      versionIndex: 0,
+    });
+  });
+
+  it("accepts versionIndex of 0", () => {
+    expect(() => parseOrThrow(PageSelectSchema, { pageNumber: 1, versionIndex: 0 })).not.toThrow();
+  });
+
+  it("rejects missing pageNumber", () => {
+    expectInvalidInput(() => parseOrThrow(PageSelectSchema, { versionIndex: 0 }), "pageNumber");
+  });
+
+  it("rejects missing versionIndex", () => {
+    expectInvalidInput(() => parseOrThrow(PageSelectSchema, { pageNumber: 1 }), "versionIndex");
+  });
+
+  it("rejects negative versionIndex", () => {
+    expectInvalidInput(() => parseOrThrow(PageSelectSchema, { pageNumber: 1, versionIndex: -1 }), "versionIndex");
+  });
+
+  it("rejects non-integer versionIndex", () => {
+    expectInvalidInput(() => parseOrThrow(PageSelectSchema, { pageNumber: 1, versionIndex: 0.5 }), "versionIndex");
+  });
+
+  it("rejects pageNumber below 1", () => {
+    expectInvalidInput(() => parseOrThrow(PageSelectSchema, { pageNumber: 0, versionIndex: 0 }), "pageNumber");
+  });
+});

--- a/src/backend/lib/validation.ts
+++ b/src/backend/lib/validation.ts
@@ -1,0 +1,89 @@
+import { z } from "zod";
+import { MIN_PAGES, MAX_PAGES } from "./constants";
+
+export const ART_STYLE_VALUES = [
+  "manga",
+  "western_comic",
+  "watercolor_storybook",
+  "minimalist_flat",
+  "vintage_newspaper",
+  "custom",
+] as const;
+
+export const CreateComicSchema = z
+  .object({
+    prompt: z.string().min(1, "prompt must not be empty"),
+    artStyle: z.enum(ART_STYLE_VALUES, {
+      error: `artStyle must be one of: ${ART_STYLE_VALUES.join(", ")}`,
+    }),
+    customStylePrompt: z.string().optional().nullable(),
+    pageCount: z
+      .number({ error: "pageCount must be a number" })
+      .int("pageCount must be an integer")
+      .min(MIN_PAGES, `pageCount must be at least ${MIN_PAGES}`)
+      .max(MAX_PAGES, `pageCount must be at most ${MAX_PAGES}`),
+  })
+  .refine(
+    (d) =>
+      d.artStyle !== "custom" ||
+      (typeof d.customStylePrompt === "string" && d.customStylePrompt.trim() !== ""),
+    { message: "customStylePrompt is required when artStyle is 'custom'", path: ["customStylePrompt"] }
+  );
+
+export const RefineComicSchema = z.object({
+  answers: z.record(z.string(), z.string(), {
+    error: "answers must be an object mapping question IDs to strings",
+  }),
+});
+
+export const RegenerateScriptSchema = z.object({
+  feedback: z
+    .string({ error: "feedback must be a string" })
+    .min(1, "feedback must not be empty")
+    .max(2000, "feedback must be at most 2000 characters"),
+});
+
+export const ApproveComicSchema = z.object({
+  script: z.record(z.string(), z.unknown()).refine((v) => v !== null && typeof v === "object", {
+    message: "script must be an object",
+  }),
+  generationMode: z.enum(["supervised", "automated"], {
+    error: "generationMode must be 'supervised' or 'automated'",
+  }),
+});
+
+export const PageGenerateSchema = z.object({
+  pageNumber: z
+    .number({ error: "pageNumber must be a number" })
+    .int("pageNumber must be an integer")
+    .min(1, "pageNumber must be at least 1"),
+});
+
+export const PageRegenerateSchema = z.object({
+  pageNumber: z
+    .number({ error: "pageNumber must be a number" })
+    .int("pageNumber must be an integer")
+    .min(1, "pageNumber must be at least 1"),
+  feedback: z.string().max(2000, "feedback must be at most 2000 characters").optional().nullable(),
+});
+
+export const PageSelectSchema = z.object({
+  pageNumber: z
+    .number({ error: "pageNumber must be a number" })
+    .int("pageNumber must be an integer")
+    .min(1, "pageNumber must be at least 1"),
+  versionIndex: z
+    .number({ error: "versionIndex must be a number" })
+    .int("versionIndex must be an integer")
+    .min(0, "versionIndex must be at least 0"),
+});
+
+export function parseOrThrow<T>(schema: z.ZodType<T>, body: unknown): T {
+  const result = schema.safeParse(body);
+  if (!result.success) {
+    const issue = result.error.issues[0];
+    const field = issue.path.length > 0 ? issue.path.join(".") : "body";
+    throw new Error(`INVALID_INPUT: ${field}: ${issue.message}`);
+  }
+  return result.data;
+}

--- a/src/backend/lib/validation.ts
+++ b/src/backend/lib/validation.ts
@@ -43,10 +43,39 @@ export const RegenerateScriptSchema = z.object({
     .max(2000, "feedback must be at most 2000 characters"),
 });
 
+const DialogueLineSchema = z.object({
+  speaker: z.string(),
+  text: z.string(),
+});
+
+const ScriptPanelSchema = z.object({
+  panelNumber: z.number().int(),
+  description: z.string(),
+  dialogue: z.array(DialogueLineSchema),
+  caption: z.string().optional(),
+});
+
+const ScriptPageSchema = z.object({
+  pageNumber: z.number().int(),
+  panels: z.array(ScriptPanelSchema),
+});
+
+const CharacterSchema = z.object({
+  name: z.string(),
+  appearance: z.string(),
+  clothing: z.string(),
+  personality: z.string(),
+});
+
+export const ScriptSchema = z.object({
+  title: z.string(),
+  synopsis: z.string(),
+  characters: z.array(CharacterSchema),
+  pages: z.array(ScriptPageSchema),
+});
+
 export const ApproveComicSchema = z.object({
-  script: z.record(z.string(), z.unknown()).refine((v) => v !== null && typeof v === "object", {
-    message: "script must be an object",
-  }),
+  script: ScriptSchema,
   generationMode: z.enum(["supervised", "automated"], {
     error: "generationMode must be 'supervised' or 'automated'",
   }),


### PR DESCRIPTION
## Summary
- Created `src/backend/lib/validation.ts` with Zod schemas for all 7 API request bodies (create comic, refine, regenerate script, approve, page generate, page regenerate, page select)
- Replaced manual hand-rolled validation in all 7 handlers with `parseOrThrow(Schema, body)` — removes ~150 lines of duplicated guard code
- Added 46 tests in `src/backend/lib/__tests__/validation.test.ts` covering edge cases: empty strings, negative numbers, missing fields, out-of-range values, wrong types, and the custom artStyle refinement

## Test plan
- [ ] `npm run test -- --run` passes (252 tests, 10 files)
- [ ] `npm run lint` passes
- [ ] `npx tsc --noEmit` passes
- [ ] Invalid input to any route returns `400` with `{ error: "field: message" }` — no stack traces

🤖 Generated with [Claude Code](https://claude.com/claude-code)