### PR TITLE
feat(frontend): guest comic claiming on signup

### DIFF
--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -1,5 +1,10 @@
+import { Suspense } from "react";
 import LoginPage from "@/frontend/auth/LoginPage";
 
 export default function Page() {
-  return <LoginPage />;
+  return (
+    <Suspense>
+      <LoginPage />
+    </Suspense>
+  );
 }

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -1,5 +1,10 @@
+import { Suspense } from "react";
 import SignupPage from "@/frontend/auth/SignupPage";
 
 export default function Page() {
-  return <SignupPage />;
+  return (
+    <Suspense>
+      <SignupPage />
+    </Suspense>
+  );
 }

--- a/src/frontend/auth/SignupPage.tsx
+++ b/src/frontend/auth/SignupPage.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useState } from "react";
 import { supabase } from "@/frontend/lib/supabase-browser";
 import { safeRedirect } from "@/frontend/lib/auth";
@@ -9,6 +9,7 @@ import AuthField from "./AuthField";
 import GoogleOAuthSection from "./GoogleOAuthSection";
 
 export default function SignupPage() {
+  const router = useRouter();
   const searchParams = useSearchParams();
   const redirect = safeRedirect(searchParams.get("redirect"));
 
@@ -20,7 +21,6 @@ export default function SignupPage() {
   }>({});
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
-  const [showConfirmation, setShowConfirmation] = useState(false);
 
   function validate() {
     const errors: { email?: string; password?: string } = {};
@@ -59,7 +59,7 @@ export default function SignupPage() {
       setError(authError.message);
       return;
     }
-    setShowConfirmation(true);
+    router.push(redirect);
   }
 
   async function handleOAuth() {
@@ -69,26 +69,6 @@ export default function SignupPage() {
         redirectTo: `${process.env.NEXT_PUBLIC_BASE_URL}/auth/callback?redirect=${encodeURIComponent(redirect)}`,
       },
     });
-  }
-
-  if (showConfirmation) {
-    return (
-      <main className="flex min-h-screen items-center justify-center px-4">
-        <div className="w-full max-w-sm text-center">
-          <h1 className="mb-3 text-2xl font-bold text-text">Check your email</h1>
-          <p className="mb-6 text-sm text-text-secondary">
-            We sent a confirmation link to <strong>{email}</strong>. Click it to
-            activate your account.
-          </p>
-          <Link
-            href="/auth/login"
-            className="text-sm font-medium text-primary hover:underline"
-          >
-            Back to log in
-          </Link>
-        </div>
-      </main>
-    );
   }
 
   return (

--- a/src/frontend/auth/SignupPage.tsx
+++ b/src/frontend/auth/SignupPage.tsx
@@ -21,6 +21,7 @@ export default function SignupPage() {
   }>({});
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [confirmationSent, setConfirmationSent] = useState(false);
 
   function validate() {
     const errors: { email?: string; password?: string } = {};
@@ -59,7 +60,7 @@ export default function SignupPage() {
       setError(authError.message);
       return;
     }
-    router.push(redirect);
+    setConfirmationSent(true);
   }
 
   async function handleOAuth() {
@@ -69,6 +70,19 @@ export default function SignupPage() {
         redirectTo: `${process.env.NEXT_PUBLIC_BASE_URL}/auth/callback?redirect=${encodeURIComponent(redirect)}`,
       },
     });
+  }
+
+  if (confirmationSent) {
+    return (
+      <main className="flex min-h-screen items-center justify-center px-4">
+        <div className="w-full max-w-sm text-center">
+          <h1 className="mb-4 text-2xl font-bold text-text">Check your email</h1>
+          <p className="text-sm text-text-secondary">
+            We sent a confirmation link to <strong>{email}</strong>. Click it to activate your account.
+          </p>
+        </div>
+      </main>
+    );
   }
 
   return (

--- a/src/frontend/auth/SignupPage.tsx
+++ b/src/frontend/auth/SignupPage.tsx
@@ -21,7 +21,6 @@ export default function SignupPage() {
   }>({});
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
-  const [confirmationSent, setConfirmationSent] = useState(false);
 
   function validate() {
     const errors: { email?: string; password?: string } = {};
@@ -60,7 +59,7 @@ export default function SignupPage() {
       setError(authError.message);
       return;
     }
-    setConfirmationSent(true);
+    router.push(redirect);
   }
 
   async function handleOAuth() {
@@ -70,19 +69,6 @@ export default function SignupPage() {
         redirectTo: `${process.env.NEXT_PUBLIC_BASE_URL}/auth/callback?redirect=${encodeURIComponent(redirect)}`,
       },
     });
-  }
-
-  if (confirmationSent) {
-    return (
-      <main className="flex min-h-screen items-center justify-center px-4">
-        <div className="w-full max-w-sm text-center">
-          <h1 className="mb-4 text-2xl font-bold text-text">Check your email</h1>
-          <p className="text-sm text-text-secondary">
-            We sent a confirmation link to <strong>{email}</strong>. Click it to activate your account.
-          </p>
-        </div>
-      </main>
-    );
   }
 
   return (

--- a/src/frontend/auth/__tests__/SignupPage.test.tsx
+++ b/src/frontend/auth/__tests__/SignupPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import SignupPage from "../SignupPage";
@@ -194,13 +194,13 @@ describe("Successful Submit", () => {
     );
   });
 
-  it("shows a 'check your email' confirmation message instead of redirecting", async () => {
+  it("redirects to the redirect param after successful signup", async () => {
     mockSignUp.mockResolvedValue({ data: { user: {} }, error: null });
+    mockSearchParams = new URLSearchParams("redirect=/comic/abc");
     const { user } = setup();
     await fillAndSubmit(user);
 
-    expect(await screen.findByText(/check your email/i)).toBeInTheDocument();
-    expect(mockPush).not.toHaveBeenCalled();
+    await waitFor(() => expect(mockPush).toHaveBeenCalledWith("/comic/abc"));
   });
 });
 

--- a/src/frontend/comic-viewer/ComicViewerPage.tsx
+++ b/src/frontend/comic-viewer/ComicViewerPage.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { getComic, deleteComic } from "@/frontend/lib/api";
+import { getComic, deleteComic, claimComic } from "@/frontend/lib/api";
 import { supabase } from "@/frontend/lib/supabase-browser";
 import type { Comic } from "@/frontend/lib/types";
 import type { User } from "@supabase/supabase-js";
@@ -34,6 +34,13 @@ export default function ComicViewerPage({ comicId }: { comicId: string }) {
         setComic(loaded);
         setCurrentUser(user);
         setPhase(loaded.status === "complete" ? "complete" : "generating");
+        if (user && loaded.userId === null) {
+          claimComic(comicId)
+            .then(() => {
+              setComic(prev => prev ? { ...prev, userId: user.id } : prev);
+            })
+            .catch(() => undefined);
+        }
       })
       .catch((err: unknown) => {
         if (err instanceof Error && err.message === "Comic not found") {

--- a/src/frontend/lib/api.ts
+++ b/src/frontend/lib/api.ts
@@ -162,6 +162,18 @@ export async function deleteComic(id: string): Promise<void> {
   if (!res.ok) throw new Error("Failed to delete comic");
 }
 
+export async function claimComic(id: string): Promise<{ success: boolean }> {
+  if (USE_MOCK) {
+    await delay(300);
+    return { success: true };
+  }
+  const res = await fetch(`/api/comic/${id}/claim`, { method: "PUT" });
+  if (res.status === 401) throw new Error("Authentication required");
+  if (res.status === 403) throw new Error("Comic already owned by another user");
+  if (!res.ok) throw new Error("Failed to claim comic");
+  return res.json();
+}
+
 // ---------------------------------------------------------------------------
 // Supervised Mode endpoints (#20)
 // ---------------------------------------------------------------------------

--- a/src/frontend/lib/api.ts
+++ b/src/frontend/lib/api.ts
@@ -145,7 +145,7 @@ export interface LibraryResponse {
 
 export async function getLibraryComics(): Promise<LibraryResponse> {
   if (USE_MOCK) return mockGetLibraryComics();
-  const res = await fetch("/api/comic?library=true");
+  const res = await fetch("/api/library");
   if (res.status === 401) throw new Error("Authentication required");
   if (!res.ok) throw new Error("Failed to load library");
   return res.json();


### PR DESCRIPTION
## Summary

- Auto-claim guest comics on return: `ComicViewerPage` calls `claimComic()` on mount when a logged-in user views a comic with `userId === null`
- Add `claimComic(id)` API client function (`PUT /api/comic/{id}/claim`)
- Fix `SignupPage` to redirect to `?redirect=` param after successful signup (removing stale email-confirmation screen that blocked the claiming flow)
- Fix `SignupPage` test: rewrite to assert redirect behavior instead of confirmation screen
- Fix library 405 regression: `getLibraryComics()` was calling `/api/comic?library=true` — corrected to `/api/library`
- Add `<Suspense>` wrappers to login/signup page routes

## Test plan

- [ ] `npm run test -- --run` → all 211 tests pass
- [ ] Guest creates comic → clicks "Sign up to save" banner → signs up → redirected back to comic → comic appears in their library
- [ ] Library page loads without 405 error
- [ ] Signing up without a `?redirect=` param redirects to `/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)