### PR TITLE
fix(frontend): wrap auth pages in Suspense for Vercel build

### DIFF
--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -1,5 +1,10 @@
+import { Suspense } from "react";
 import LoginPage from "@/frontend/auth/LoginPage";
 
 export default function Page() {
-  return <LoginPage />;
+  return (
+    <Suspense>
+      <LoginPage />
+    </Suspense>
+  );
 }

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -1,5 +1,10 @@
+import { Suspense } from "react";
 import SignupPage from "@/frontend/auth/SignupPage";
 
 export default function Page() {
-  return <SignupPage />;
+  return (
+    <Suspense>
+      <SignupPage />
+    </Suspense>
+  );
 }


### PR DESCRIPTION
## Summary

- Wraps `LoginPage` and `SignupPage` in `<Suspense>` in their route page files
- Fixes Vercel production build failure caused by `useSearchParams()` being called outside a Suspense boundary

## Root cause

Next.js requires any component that calls `useSearchParams()` to be wrapped in `<Suspense>` during static page generation. The build was failing at `/auth/login` with:

```
useSearchParams() should be wrapped in a suspense boundary at page "/auth/login"
```

## Test plan

- [ ] Vercel build completes successfully
- [ ] `/auth/login` and `/auth/signup` pages load and function correctly in production