### PR TITLE
fix(frontend): remove email verification on signup

### DIFF
--- a/src/frontend/auth/SignupPage.tsx
+++ b/src/frontend/auth/SignupPage.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useState } from "react";
 import { supabase } from "@/frontend/lib/supabase-browser";
 import { safeRedirect } from "@/frontend/lib/auth";
@@ -11,6 +11,7 @@ import GoogleOAuthSection from "./GoogleOAuthSection";
 export default function SignupPage() {
   const searchParams = useSearchParams();
   const redirect = safeRedirect(searchParams.get("redirect"));
+  const router = useRouter();
 
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -20,7 +21,6 @@ export default function SignupPage() {
   }>({});
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
-  const [showConfirmation, setShowConfirmation] = useState(false);
 
   function validate() {
     const errors: { email?: string; password?: string } = {};
@@ -47,19 +47,13 @@ export default function SignupPage() {
     }
     setFieldErrors({});
     setLoading(true);
-    const { error: authError } = await supabase.auth.signUp({
-      email,
-      password,
-      options: {
-        emailRedirectTo: `${process.env.NEXT_PUBLIC_BASE_URL}/auth/callback`,
-      },
-    });
+    const { error: authError } = await supabase.auth.signUp({ email, password });
     setLoading(false);
     if (authError) {
       setError(authError.message);
       return;
     }
-    setShowConfirmation(true);
+    router.push(redirect);
   }
 
   async function handleOAuth() {
@@ -69,26 +63,6 @@ export default function SignupPage() {
         redirectTo: `${process.env.NEXT_PUBLIC_BASE_URL}/auth/callback?redirect=${encodeURIComponent(redirect)}`,
       },
     });
-  }
-
-  if (showConfirmation) {
-    return (
-      <main className="flex min-h-screen items-center justify-center px-4">
-        <div className="w-full max-w-sm text-center">
-          <h1 className="mb-3 text-2xl font-bold text-text">Check your email</h1>
-          <p className="mb-6 text-sm text-text-secondary">
-            We sent a confirmation link to <strong>{email}</strong>. Click it to
-            activate your account.
-          </p>
-          <Link
-            href="/auth/login"
-            className="text-sm font-medium text-primary hover:underline"
-          >
-            Back to log in
-          </Link>
-        </div>
-      </main>
-    );
   }
 
   return (

--- a/src/frontend/auth/SignupPage.tsx
+++ b/src/frontend/auth/SignupPage.tsx
@@ -12,7 +12,6 @@ export default function SignupPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const redirect = safeRedirect(searchParams.get("redirect"));
-  const router = useRouter();
 
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");


### PR DESCRIPTION
## Summary

- Removes the "Check your email" confirmation screen after signup
- Redirects the user directly to the app after successful signup
- Removes `emailRedirectTo` option from `signUp()` call (no longer needed)

## Required Supabase dashboard change

Go to **Authentication → Providers → Email** and disable **"Confirm email"**. Without this, Supabase will still send a verification email and the session won't be active until the user clicks it.

## Test plan

- [ ] Confirm email toggle is OFF in Supabase dashboard
- [ ] Sign up with a new email — user is redirected to `/` immediately
- [ ] No confirmation email is sent