### PR TITLE
chore: modularise CLAUDE.md, update README with Mermaid diagrams, add pending checklist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,127 +12,13 @@ npm run test           # Run Vitest
 npm run test:coverage  # Vitest with coverage report (70% threshold)
 ```
 
-## Architecture
+@docs/claude/architecture.md
 
-**Next.js 16 App Router** project. Source lives under `src/`.
+@docs/claude/testing.md
 
-### Directory layout
+@docs/claude/environment.md
 
-```
-src/
-├── app/                        # Next.js routes
-│   ├── layout.tsx              # Root layout (Geist fonts, <Header />)
-│   ├── page.tsx                # / → LandingPage
-│   ├── auth/
-│   │   ├── login/page.tsx      # /auth/login
-│   │   ├── signup/page.tsx     # /auth/signup
-│   │   └── callback/route.ts   # OAuth callback (Supabase code exchange)
-│   ├── create/page.tsx         # /create?id=... → QAPage
-│   ├── script/[id]/page.tsx    # /script/[id] → ScriptReviewPage
-│   └── comic/[id]/page.tsx     # /comic/[id] → ComicViewerPage
-└── frontend/                   # UI components, lib, tests
-    ├── landing/
-    ├── auth/
-    ├── qa/
-    ├── script-review/
-    ├── comic-viewer/
-    ├── ui/                     # Shared UI (Header)
-    └── lib/
-        ├── api.ts              # API client with mock fallback
-        ├── types.ts            # Shared types & constants
-        ├── auth.ts             # safeRedirect helper
-        └── supabase-browser.ts # Browser Supabase client
-```
-
-### Pages & routes
-
-| Route | Component | Purpose |
-|-------|-----------|---------|
-| `/` | LandingPage | Prompt input, art style, page count, "Surprise Me" |
-| `/auth/login` | LoginPage | Email/password + Google OAuth |
-| `/auth/signup` | SignupPage | Email/password + Google OAuth |
-| `/create?id=...` | QAPage | Follow-up Q&A refinement |
-| `/script/[id]` | ScriptReviewPage | Script review, edit, regenerate, mode selection |
-| `/comic/[id]` | ComicViewerPage | Paginated comic viewer |
-
-### API endpoints (consumed by `src/frontend/lib/api.ts`)
-
-```
-POST   /api/comic                       # Create comic
-POST   /api/comic/random-idea           # Generate random idea
-GET    /api/comic/[id]                  # Fetch comic
-POST   /api/comic/[id]/refine           # Submit Q&A answers
-POST   /api/comic/[id]/script/generate  # Generate script
-POST   /api/comic/[id]/script/regenerate # Regenerate with feedback
-PUT    /api/comic/[id]/approve          # Approve script + select mode
-POST   /api/comic/[id]/generate-all     # Trigger image generation
-```
-
-Set `NEXT_PUBLIC_USE_MOCK_API=true` in `.env.local` to use mock implementations instead of a live backend.
-
-## Styling
-
-Tailwind CSS v4 (imported via `@import "tailwindcss"` in `globals.css`, not the v3 plugin syntax). Design system: **Ink & Pop**.
-
-CSS variables declared in `globals.css`:
-- Colors: `--color-primary` (#6c3ce1 purple), `--color-secondary` (#ff6b35 orange), plus text/surface/border/muted/status tokens
-- `--background` / `--foreground` for light/dark mode (`prefers-color-scheme`)
-- `--font-sans` / `--font-mono` wired to Geist font variables
-
-## TypeScript
-
-Strict mode. Path alias `@/*` resolves to `src/` (e.g. `@/frontend/lib/api`).
-
-## Testing
-
-**Vitest + React Testing Library + MSW v2.** Tests live in `__tests__/` beside the component they test. Coverage threshold: 70% lines/branches/functions/statements.
-
-MSW setup: `server` from `msw/node`, `http` + `HttpResponse`, canonical lifecycle (`listen` / `resetHandlers` / `close`). Per-test overrides via `server.use()`. Mock Supabase and `next/navigation` are patched in `vitest.setup.ts`.
-
-## Environment variables
-
-| Variable | Scope | Purpose |
-|----------|-------|---------|
-| `NEXT_PUBLIC_SUPABASE_URL` | browser | Supabase project URL |
-| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | browser | Supabase anon key |
-| `NEXT_PUBLIC_BASE_URL` | browser | App base URL |
-| `NEXT_PUBLIC_USE_MOCK_API` | browser | `true` = use mock API client |
-| `SUPABASE_SERVICE_ROLE_KEY` | server only | Server-side Supabase ops |
-| `GEMINI_API_KEY` | server only | Image generation (backend) |
-
-## ESLint
-
-Flat config (`eslint.config.mjs`) using `eslint-config-next/core-web-vitals` + `eslint-config-next/typescript`.
-
-## Security
-
-See [`docs/security.md`](docs/security.md) for the full OWASP Top 10 checklist and Comicly-specific mitigations.
-
-### Gitleaks — pre-commit secrets detection
-
-Gitleaks runs automatically in CI. To run locally before committing:
-
-```bash
-# Scan staged changes
-gitleaks protect --staged --verbose
-
-# Add as a pre-commit hook (one-time setup)
-echo -e '#!/bin/sh\ngitleaks protect --staged --verbose' > .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
-```
-
-### Security reviewer agent
-
-Run the `security-reviewer` agent on every PR that touches `src/backend/` or `src/app/api/`:
-
-```
-/agents security-reviewer
-```
-
-Or invoke it from Claude Code by asking: "Run the security reviewer on this PR."
-
-### Error response convention
-
-All API errors must return `{ error: "Human-readable message" }` with an appropriate HTTP status. Never return stack traces or internal error details to the client.
+@docs/claude/security.md
 
 ## Note
 

--- a/README.md
+++ b/README.md
@@ -1,36 +1,198 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Comicly
 
-## Getting Started
+AI-powered comic book generator — turn any story idea into a fully illustrated comic strip.
 
-First, run the development server:
+[![CI](https://github.com/Reghunaath/comicly/actions/workflows/ci.yml/badge.svg)](https://github.com/Reghunaath/comicly/actions/workflows/ci.yml)
+[![Deploy](https://img.shields.io/badge/deploy-vercel-black)](https://comicly.vercel.app)
 
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+**Live demo:** https://comicly.vercel.app
+
+---
+
+## Features
+
+- **AI script generation** — Gemini crafts a full comic script (title, synopsis, characters, panels, dialogue) from your prompt
+- **Follow-up Q&A refinement** — targeted questions deepen the story before the script is written
+- **Supervised & automated modes** — review and approve each page individually, or generate everything in one shot
+- **Multimodal image generation** — character reference sheet + previous page passed as context to Gemini for visual consistency
+- **Page versioning** — regenerate any page up to 4 times and pick the best version
+- **Guest mode** — no login required; comics can be claimed to an account after signup
+- **Library** — authenticated users see all their comics in one place
+- **PDF export & share link** — download a PDF or copy a public URL
+
+---
+
+## Architecture
+
+### System overview
+
+```mermaid
+graph TD
+    subgraph Browser["Browser (Next.js App Router)"]
+        LP[Landing Page] --> QA[Q&A Page]
+        QA --> SR[Script Review]
+        SR --> CV[Comic Viewer]
+        SR --> PV[Supervised Review]
+        AUTH[Auth Pages]
+        LIB[Library]
+    end
+
+    subgraph API["Next.js API Routes"]
+        R1["POST /api/comic"]
+        R2["POST /api/comic/:id/script/generate"]
+        R3["PUT  /api/comic/:id/approve"]
+        R4["POST /api/comic/:id/generate-all"]
+        R5["GET  /api/library"]
+    end
+
+    subgraph Services["Backend Services"]
+        DB[(Supabase<br/>PostgreSQL)]
+        STORAGE[(Supabase<br/>Storage)]
+        GEMINI[Google<br/>Gemini AI]
+    end
+
+    subgraph CICD["CI/CD"]
+        GHA[GitHub Actions]
+        VERCEL[Vercel]
+    end
+
+    LP -->|"fetch()"| R1
+    QA -->|"fetch()"| R1
+    SR -->|"fetch()"| R2
+    SR -->|"fetch()"| R3
+    PV -->|"fetch()"| R4
+    LIB -->|"fetch()"| R5
+    R1 --> DB
+    R2 --> DB
+    R3 --> DB
+    R4 --> DB
+    R4 --> STORAGE
+    R4 --> GEMINI
+    R2 --> GEMINI
+    GHA -->|"preview & prod deploy"| VERCEL
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+### Comic creation flow
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+```mermaid
+flowchart LR
+    A([User Prompt]) --> B["POST /api/comic<br/>status: input"]
+    B --> C["Q&A Refinement<br/>status: script_pending"]
+    C --> D["Script Generation<br/>Gemini API<br/>status: script_draft"]
+    D --> E{User Review}
+    E -->|Regenerate| D
+    E -->|Approve| F["status: script_approved"]
+    F --> G{Mode}
+    G -->|Automated| H["generate-all<br/>Char. sheet + pages<br/>status: generating"]
+    G -->|Supervised| I["Page-by-page<br/>review & select"]
+    H --> J([Comic Complete])
+    I --> J
+```
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+---
 
-## Learn More
+## Tech stack
 
-To learn more about Next.js, take a look at the following resources:
+| Layer | Technology |
+|---|---|
+| Framework | Next.js 16 (App Router) |
+| Frontend | React 19, Tailwind CSS v4 |
+| Auth & DB | Supabase (PostgreSQL + Row-Level Security) |
+| AI | Google Gemini (`@google/genai`) |
+| Validation | Zod |
+| Testing | Vitest, React Testing Library, MSW v2, Playwright |
+| CI/CD | GitHub Actions, Vercel |
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+---
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+## Getting started
 
-## Deploy on Vercel
+### Prerequisites
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+- Node.js 18+
+- A [Supabase](https://supabase.com) project
+- A [Google AI Studio](https://aistudio.google.com) API key
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+### Setup
+
+```bash
+git clone https://github.com/Reghunaath/comicly.git
+cd comicly
+npm install
+cp .env.example .env.local   # then fill in the values below
+npm run dev
+```
+
+Open [http://localhost:3000](http://localhost:3000).
+
+### Environment variables
+
+| Variable | Scope | Purpose |
+|---|---|---|
+| `NEXT_PUBLIC_SUPABASE_URL` | browser | Supabase project URL |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | browser | Supabase anon key |
+| `NEXT_PUBLIC_BASE_URL` | browser | App base URL (e.g. `http://localhost:3000`) |
+| `NEXT_PUBLIC_USE_MOCK_API` | browser | `true` to use mock API (no real keys needed) |
+| `SUPABASE_SERVICE_ROLE_KEY` | server only | Server-side Supabase operations |
+| `GEMINI_API_KEY` | server only | Google Gemini image & text generation |
+
+---
+
+## Commands
+
+```bash
+npm run dev               # Start dev server at http://localhost:3000
+npm run build             # Production build
+npm run lint              # ESLint
+npm run test              # Vitest unit & component tests
+npm run test:coverage     # Vitest with coverage report (70% threshold)
+npm exec playwright test  # Playwright E2E tests
+```
+
+---
+
+## Project structure
+
+```
+src/
+├── app/                  # Next.js routes & API handlers
+│   ├── api/comic/        # REST API (create, script, approve, generate, library)
+│   ├── auth/             # Login, signup, OAuth callback
+│   ├── comic/[id]/       # Comic viewer
+│   ├── create/           # Q&A refinement wizard step
+│   ├── library/          # User comic library
+│   ├── review/[id]/      # Supervised page review
+│   └── script/[id]/      # Script review & approval
+├── backend/
+│   ├── handlers/         # Business logic (one file per endpoint)
+│   └── lib/              # DB, AI, validation, Supabase helpers
+└── frontend/
+    ├── auth/             # Login & signup components
+    ├── comic-viewer/     # Viewer page component
+    ├── landing/          # Home page component
+    ├── library/          # Library page component
+    ├── qa/               # Q&A page component
+    ├── script-review/    # Script review component
+    └── lib/              # API client, types, auth helpers
+```
+
+---
+
+## CI/CD pipeline
+
+| Job | What it runs |
+|---|---|
+| Lint | ESLint |
+| Type Check | `tsc --noEmit` |
+| Unit Tests | Vitest with 70% coverage threshold |
+| E2E Tests | Playwright on Chromium |
+| Security | `npm audit` + Gitleaks secret scan |
+| AI Code Review | Claude Code (C.L.E.A.R. framework) on every PR |
+
+Every push to `main` triggers a production deploy to Vercel. Every PR gets a preview deploy.
+
+---
+
+## Team
+
+Built by **Reghunaath** and **Qingyang** for the AI-Assisted Coding course (Spring 2026).

--- a/docs/claude/architecture.md
+++ b/docs/claude/architecture.md
@@ -1,0 +1,74 @@
+# Architecture
+
+**Next.js 16 App Router** project. Source lives under `src/`.
+
+## Directory layout
+
+```
+src/
+├── app/                        # Next.js routes
+│   ├── layout.tsx              # Root layout (Geist fonts, <Header />)
+│   ├── page.tsx                # / → LandingPage
+│   ├── auth/
+│   │   ├── login/page.tsx      # /auth/login
+│   │   ├── signup/page.tsx     # /auth/signup
+│   │   └── callback/route.ts   # OAuth callback (Supabase code exchange)
+│   ├── create/page.tsx         # /create?id=... → QAPage
+│   ├── script/[id]/page.tsx    # /script/[id] → ScriptReviewPage
+│   └── comic/[id]/page.tsx     # /comic/[id] → ComicViewerPage
+└── frontend/                   # UI components, lib, tests
+    ├── landing/
+    ├── auth/
+    ├── qa/
+    ├── script-review/
+    ├── comic-viewer/
+    ├── ui/                     # Shared UI (Header)
+    └── lib/
+        ├── api.ts              # API client with mock fallback
+        ├── types.ts            # Shared types & constants
+        ├── auth.ts             # safeRedirect helper
+        └── supabase-browser.ts # Browser Supabase client
+```
+
+## Pages & routes
+
+| Route | Component | Purpose |
+|-------|-----------|---------|
+| `/` | LandingPage | Prompt input, art style, page count, "Surprise Me" |
+| `/auth/login` | LoginPage | Email/password + Google OAuth |
+| `/auth/signup` | SignupPage | Email/password + Google OAuth |
+| `/create?id=...` | QAPage | Follow-up Q&A refinement |
+| `/script/[id]` | ScriptReviewPage | Script review, edit, regenerate, mode selection |
+| `/comic/[id]` | ComicViewerPage | Paginated comic viewer |
+
+## API endpoints (consumed by `src/frontend/lib/api.ts`)
+
+```
+POST   /api/comic                        # Create comic
+POST   /api/comic/random-idea            # Generate random idea
+GET    /api/comic/[id]                   # Fetch comic
+POST   /api/comic/[id]/refine            # Submit Q&A answers
+POST   /api/comic/[id]/script/generate   # Generate script
+POST   /api/comic/[id]/script/regenerate # Regenerate with feedback
+PUT    /api/comic/[id]/approve           # Approve script + select mode
+POST   /api/comic/[id]/generate-all      # Trigger image generation
+```
+
+Set `NEXT_PUBLIC_USE_MOCK_API=true` in `.env.local` to use mock implementations instead of a live backend.
+
+## TypeScript
+
+Strict mode. Path alias `@/*` resolves to `src/` (e.g. `@/frontend/lib/api`).
+
+## Styling
+
+Tailwind CSS v4 (imported via `@import "tailwindcss"` in `globals.css`, not the v3 plugin syntax). Design system: **Ink & Pop**.
+
+CSS variables declared in `globals.css`:
+- Colors: `--color-primary` (#6c3ce1 purple), `--color-secondary` (#ff6b35 orange), plus text/surface/border/muted/status tokens
+- `--background` / `--foreground` for light/dark mode (`prefers-color-scheme`)
+- `--font-sans` / `--font-mono` wired to Geist font variables
+
+## ESLint
+
+Flat config (`eslint.config.mjs`) using `eslint-config-next/core-web-vitals` + `eslint-config-next/typescript`.

--- a/docs/claude/environment.md
+++ b/docs/claude/environment.md
@@ -1,0 +1,10 @@
+# Environment Variables
+
+| Variable | Scope | Purpose |
+|----------|-------|---------|
+| `NEXT_PUBLIC_SUPABASE_URL` | browser | Supabase project URL |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | browser | Supabase anon key |
+| `NEXT_PUBLIC_BASE_URL` | browser | App base URL |
+| `NEXT_PUBLIC_USE_MOCK_API` | browser | `true` = use mock API client |
+| `SUPABASE_SERVICE_ROLE_KEY` | server only | Server-side Supabase ops |
+| `GEMINI_API_KEY` | server only | Image generation (backend) |

--- a/docs/claude/security.md
+++ b/docs/claude/security.md
@@ -1,0 +1,29 @@
+# Security
+
+See [`docs/security.md`](../security.md) for the full OWASP Top 10 checklist and Comicly-specific mitigations.
+
+## Gitleaks — pre-commit secrets detection
+
+Gitleaks runs automatically in CI and via the Stop hook. To run locally before committing:
+
+```bash
+# Scan staged changes
+gitleaks protect --staged --verbose
+
+# Add as a pre-commit hook (one-time setup)
+echo -e '#!/bin/sh\ngitleaks protect --staged --verbose' > .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
+```
+
+## Security reviewer agent
+
+Run the `security-reviewer` agent on every PR that touches `src/backend/` or `src/app/api/`:
+
+```
+/agents security-reviewer
+```
+
+Or invoke it from Claude Code by asking: "Run the security reviewer on this PR."
+
+## Error response convention
+
+All API errors must return `{ error: "Human-readable message" }` with an appropriate HTTP status. Never return stack traces or internal error details to the client.

--- a/docs/claude/testing.md
+++ b/docs/claude/testing.md
@@ -1,0 +1,28 @@
+# Testing
+
+**Vitest + React Testing Library + MSW v2.** Tests live in `__tests__/` beside the component they test. Coverage threshold: 70% lines/branches/functions/statements.
+
+## MSW setup
+
+`server` from `msw/node`, `http` + `HttpResponse`, canonical lifecycle (`listen` / `resetHandlers` / `close`). Per-test overrides via `server.use()`. Mock Supabase and `next/navigation` are patched in `vitest.setup.ts`.
+
+## E2E
+
+Playwright config at `playwright.config.ts`. E2E specs live in `e2e/`. Run with `npm exec playwright test`.
+
+Use `page.route()` network interception to mock API responses — avoid real Gemini or Supabase calls in E2E.
+
+## Commands
+
+```bash
+npm run test           # Run Vitest (watch mode off in CI)
+npm run test:coverage  # Vitest with coverage report (70% threshold)
+npm exec playwright test  # Run E2E tests
+```
+
+## TDD workflow
+
+Follow red-green-refactor:
+1. Commit failing tests first (`test(scope): add failing tests for X (#N)`)
+2. Implement until tests pass (`feat(scope): implement X (#N)`)
+3. Refactor (`refactor(scope): clean up X (#N)`)

--- a/references/pending-checklist.md
+++ b/references/pending-checklist.md
@@ -1,0 +1,65 @@
+# Pending Requirements Checklist
+
+## High Priority
+
+### CI/CD Pipeline
+
+- [x] Add Vercel preview deploy step to `.github/workflows/ci.yml`
+- [x] Add Vercel production deploy step on merge to main in `ci.yml`
+
+### Team Process — Sprint Documentation
+
+- [x] Create `docs/sprints/sprint-1-plan.md` (issue list, assignments, goals)
+- [x] Create `docs/sprints/sprint-1-retro.md` (went well / didn't / change — 3 items each)
+- [x] Create `docs/sprints/sprint-2-plan.md`
+- [x] Create `docs/sprints/sprint-2-retro.md`
+- [x] Create `docs/sprints/sprint-3-plan.md`
+- [x] Create `docs/sprints/sprint-3-retro.md`
+
+### Documentation
+
+- [x] Replace `README.md` boilerplate with a proper project README including a Mermaid architecture diagram
+
+### Claude Code — CLAUDE.md Modular Organization
+
+- [x] Refactor `CLAUDE.md` to use `@import` directives for modular sub-files (e.g. `@claude/architecture.md`, `@claude/testing.md`)
+
+---
+
+## Medium Priority
+
+### Claude Code — Skills
+
+- [ ] Create a visible v2 improvement commit for at least one skill (e.g. `commit-and-push` or `msw-mock`) with a meaningful change based on real usage
+
+### Team Process — Async Standups
+
+- [x] Document 3+ async standups per sprint per partner (GitHub Discussions posts or markdown files in `docs/standups/`)
+
+### Testing — TDD Evidence
+
+- [x] Verify git history shows red (failing tests) committed before green (implementation) for at least 3 features
+- [x] Run `npm run test:coverage` and confirm ≥70% line/branch/function/statement coverage
+
+### Claude Code — PR Evidence
+
+- [x] Ensure at least 2 PRs have AI disclosure metadata in the description (e.g. "~80% AI-generated via Claude Code")
+- [x] Ensure at least 2 PRs have C.L.E.A.R. framework review comments visible on GitHub
+
+### Claude Code — CLAUDE.md Git History
+
+- [x] Verify `git log -- CLAUDE.md` shows 5+ commits evolving the file across the project
+
+### Agents — Usage Evidence
+
+- [x] Commit at least one session log or screenshot showing security-reviewer or frontend-test-writer agent output to the repo (e.g. `docs/evidence/`)
+
+---
+
+## External Deliverables (off-repo)
+
+- [ ] Publish technical blog post on Medium or dev.to
+- [ ] Record 5–10 min video demo showcasing app + Claude Code workflow
+- [ ] Write individual reflections (500 words each partner)
+- [ ] Submit showcase form (Google Form) with project name, URLs, thumbnail, video, blog
+- [ ] Complete peer evaluations


### PR DESCRIPTION
## Summary

- Refactor `CLAUDE.md` to use `@import` directives for 4 modular sub-files (`docs/claude/architecture.md`, `testing.md`, `environment.md`, `security.md`)
- Replace boilerplate Next.js README with full project README including two Mermaid diagrams (system architecture + comic creation flow)
- Add `references/pending-checklist.md` tracking outstanding project requirements

## Test plan

- [ ] `CLAUDE.md` loads all sub-files correctly via `@import`
- [ ] Both Mermaid diagrams render on GitHub
- [ ] `npm run lint` passes
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)